### PR TITLE
Take tile file format for eco_stories

### DIFF
--- a/transforms/eco_stories.py
+++ b/transforms/eco_stories.py
@@ -1,19 +1,19 @@
 {
     'data': [
-        ('1_peopleplaneteconomy', 'People. Planet. Economy.'),
-        ('2_systemicdysfunction', 'Systemic Dysfunction'),
-        ('3_keyplayers', 'Key Players'),
-        ('4_questions', 'Insightful Questions'),
-        ('5a_day1diagnosis', 'Day 1: Shareholder-Primacy'),
-        ('5c_day1movements', 'Day 1: Movements'),
-        ('6a_day2diagnosis', 'Day 2: Performance Management'),
-        ('6c_day2movements', 'Day 2: Movements'),
-        ('7a_day3diagnosis', 'Day 3: Leadership & Education'),
-        ('7c_day3movements', 'Day 3: Movements'),
-        ('8_allmovements', 'The Movements'),
-        ('9_leversofchange', 'Levers of Change'),
-        ('10_research', 'Research, Tools & Further Reading'),
-        ('3_keyplayers', 'Contact Us'),
+        ('1_peopleplaneteconomy', 'People. Planet. Economy.', 'png'),
+        ('2_systemicdysfunction', 'Systemic Dysfunction', 'png'),
+        ('3_keyplayers', 'Key Players', 'png'),
+        ('4_questions', 'Insightful Questions', 'png'),
+        ('5a_day1diagnosis', 'Day 1: Shareholder-Primacy', 'png'),
+        ('5c_day1movements', 'Day 1: Movements', 'png'),
+        ('6a_day2diagnosis', 'Day 2: Performance Management', 'gif'),
+        ('6c_day2movements', 'Day 2: Movements', 'png'),
+        ('7a_day3diagnosis', 'Day 3: Leadership & Education', 'gif'),
+        ('7c_day3movements', 'Day 3: Movements', 'png'),
+        ('8_allmovements', 'The Movements', 'png'),
+        ('9_leversofchange', 'Levers of Change', 'png'),
+        ('10_research', 'Research, Tools & Further Reading', 'png'),
+        ('3_keyplayers', 'Contact Us', 'png'),
     ],
     'lets': {
         'storyName': '{row[1]}',
@@ -29,6 +29,6 @@
     'triples': [
         ('{query[story]}', 'vm:usesMapTiles',
             'https://opatlas-live.s3.amazonaws.com/economicsystem/{version}/'
-            'overlays/{row[0]}/{{z}}-{{x}}-{{y}}.png'),
+            'overlays/{row[0]}/{{z}}-{{x}}-{{y}}.{row[2]}'),
     ],
 }


### PR DESCRIPTION
One was accidentally uploaded as gif rather than png, so this was quick
hack to load from the right paths.

Should be reverted and use png always, but also want to do this linking
better anyway.