### PR TITLE
Changes for brightspot schema migration

### DIFF
--- a/sheet_to_triples/__main__.py
+++ b/sheet_to_triples/__main__.py
@@ -13,6 +13,12 @@ from . import (
     trans,
 )
 
+PURGE_MAP = {
+    'none': lambda _: True,
+    'geo': rdf.relates_geo_name,
+    'issues': rdf.relates_issue,
+}
+
 
 def parse_args(argv):
     parser = argparse.ArgumentParser(argv[0], description=__doc__)
@@ -26,6 +32,10 @@ def parse_args(argv):
     parser.add_argument(
         '--model-out', metavar='PATH', default='new.json',
         help='path to write new jsom file with output map model')
+    arg_purge = parser.add_argument(
+        '--purge-except', metavar='|'.join(PURGE_MAP.keys()),
+        type=PURGE_MAP.get, default='none',
+        help='Use named rule to remove some triples from existing model')
     parser.add_argument(
         '--debug', action='store_true', help='debug interactively any error')
     parser.add_argument(
@@ -39,6 +49,8 @@ def parse_args(argv):
         need_book = set(tf.name for tf in args.transform if tf.uses_sheet())
         if need_book:
             parser.error(f'transforms {need_book} require --book')
+    if not args.purge_except:
+        parser.error('--purge-except must be one of ' + arg_purge.metavar)
     return args
 
 

--- a/sheet_to_triples/field.py
+++ b/sheet_to_triples/field.py
@@ -7,6 +7,12 @@ import ast
 import re
 
 
+_TYPES = {
+    'pain': 'vm:Painpoint',
+    'brig': 'vm:Brightspot',
+}
+
+
 _CAPTYPES = {
     'socia': 'vm:capitalTypes/social',
     'finan': 'vm:capitalTypes/sharedFinancial',
@@ -15,10 +21,16 @@ _CAPTYPES = {
 }
 
 
-def _must(value):
-    """Raise ValueError if value is falsey."""
+_CAPEFFECTS = {
+    'vm:Painpoint': 'vm:harmsCapitalType',
+    'vm:Brightspot': 'vm:aidsCapitalType',
+}
+
+
+def _must(value, exception_type=ValueError):
+    """Raise exception_type if value is falsey."""
     if not value:
-        raise ValueError('false value')
+        raise exception_type('false value')
     return value
 
 
@@ -51,7 +63,19 @@ class Cell:
 
     @property
     def as_capital(self):
-        return _must(_CAPTYPES.get(self._value.strip()[:5].lower()))
+        return _must(_CAPTYPES.get(self._value.strip()[:5].lower()), TypeError)
+
+    @property
+    def as_capital_effect(self):
+        return _must(_CAPEFFECTS.get(self.as_type))
+
+    @property
+    def as_type(self):
+        return _must(_TYPES.get(self._value.strip()[:4].lower()), TypeError)
+
+    @property
+    def as_type_prefix(self):
+        return self.as_type.lower() + '-'
 
     @property
     def as_geo(self):

--- a/sheet_to_triples/run.py
+++ b/sheet_to_triples/run.py
@@ -15,12 +15,11 @@ from . import (
 class Runner:
     """Encapsulation of new data, existing model, and transform running."""
 
-    def __init__(self, books, model, verbose):
+    def __init__(self, books, model, purge_except, verbose):
         self.books = books
         self.model = model
         if model:
-            # TODO: Unconditional purging is wrong
-            rdf.purge_terms(model, verbose)
+            rdf.purge_terms(model, purge_except, verbose)
             self.graph = rdf.graph_from_model(model)
         else:
             self.graph = rdf.graph_from_triples(())
@@ -30,7 +29,7 @@ class Runner:
     def from_args(cls, args):
         book = args.book and list(map(xl.load, args.book))
         model = args.model and cls.load_model(args.model)
-        return cls(book, model, args.verbose)
+        return cls(book, model, args.purge_except, args.verbose)
 
     def run(self, transforms):
         for tf in transforms:

--- a/transforms/mgsbr_points.py
+++ b/transforms/mgsbr_points.py
@@ -1,20 +1,20 @@
 {
     'sheet': 'Brazil Pain Bright',
     'lets': {
-        'iri': 'vm:painpoint/{row[Unique Name].as_slug}',
+        'iri': '{row[Bright/Pain].as_type_prefix}{row[Unique Name].as_slug}',
     },
     'triples': [
-        ('{iri}', 'rdf:type', 'vm:Painpoint'),
+        ('{iri}', 'rdf:type', '{row[Bright/Pain].as_type}'),
         ('{iri}', 'vm:name', '{row[Painpoint / Bright spot title]}'),
         ('{iri}', 'vm:description',
             '{row[Painpoint / Bright spot description]}'),
-        ('{iri}', 'vm:harmsCapitalType',
+        ('{iri}', '{row[Bright/Pain].as_capital_effect}',
             '{row[Category / Capital].as_capital}'),
         ('{iri}', 'vm:ofStakeholder',
             'vm:stakeholder/{row[Stakeholder].as_slug}'),
         ('{iri}', 'vm:relates',
             'vm:stakeholder/{row[In relation to:].as_slug}'),
         ('{iri}', 'vm:atGeoPoint', '{row[Coordinates].as_geo}'),
-        ('{iri}', 'vm:actuallyBright', '{row[Bright/Pain].as_text}'),
+        ('{iri}', 'owl:sameAs', 'vm:painpoint/{row[Unique Name].as_slug}'),
     ],
 }

--- a/transforms/mgsbr_views.py
+++ b/transforms/mgsbr_views.py
@@ -17,11 +17,11 @@
         ('social', 'Social Capital', 'kind=capitalTypes/social'),
         ('shared', 'Shared Financial Capital',
             'kind=capitalTypes/sharedFinancial'),
-        ('environ', 'Natural Capital', 'kind=capitalTypes/environmental'),
+        ('natural', 'Natural Capital', 'kind=capitalTypes/environmental'),
     ],
     'lets': {
         'iri': 'vm:{row[0]}',
-        'version': '20210118',
+        'version': '20210127',
     },
     'triples': [
         ('{iri}', 'rdf:type', 'vm:View'),
@@ -31,5 +31,6 @@
             '{row[0]}/{{z}}-{{x}}-{{y}}.png#background:transparent'),
         ('{iri}', 'vm:useFilters', '{row[2]}'),
         ('{iri}', 'vm:asOrdinal', '{n}'),
+        ('vm:natural', 'owl:sameAs', 'vm:environ'),
     ],
 }


### PR DESCRIPTION
Make brightspots a distinct type from painpoints.

Add some (slightly messy) support for deriving type info in field.

Support rewriting IRIs using owl:sameAs as a marker.

Drive purging behaviour from new --purge-except argument.