### PR TITLE
Try workaround for spurious CI failure on install

### DIFF
--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -17,10 +17,11 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: "3.7"
+          python-version: "3.8"
       - name: install
         run: |
           pip3 install poetry
+          poetry config experimental.new-installer false
           poetry install --no-root
       - name: test
         run: |


### PR DESCRIPTION
Upstream issue:
https://github.com/python-poetry/poetry/issues/3199

Also bump Python version in CI to same as my local copy.