### PR TITLE
Various tweaks to transformation functions

### DIFF
--- a/sheet_to_triples/xlsx.py
+++ b/sheet_to_triples/xlsx.py
@@ -21,7 +21,7 @@ class Book:
     def from_path(cls, path):
         with warnings.catch_warnings():
             warnings.filterwarnings('ignore', '.*extension is not supported')
-            return cls(openpyxl.load_workbook(path))
+            return cls(openpyxl.load_workbook(path, data_only=True))
 
     def iter_rows_in_sheet(self, sheet):
         return self._book[sheet].iter_rows()


### PR DESCRIPTION
Some tweaks, which may or may not be spelled correctly:

* Cast values to string before doing string operations
* Check that an IRI for the current object can be constructed before trying to build the triple and ignore if not -- this avoids junk data in the columns used to build the IRI breaking the transform. We should at least have enough data in a row to construct a thing's IRI -- if we do not, it is not a valid thing.
* `data_only=True` on opening `.xlsx` files - my assumption here is that we do not care about Excel formulas and are merely interested in the data values within a workbook. Should probably make a matching change for `xls` files.