### PR TITLE
Add HE transforms for capability, itsystem, orgunit, project, person

### DIFF
--- a/transforms/he/he_capability.py
+++ b/transforms/he/he_capability.py
@@ -1,0 +1,16 @@
+# use "Highways > 000 Data Ingest > capability2activity.xlsx"
+{
+    'sheet': 'capability',
+    'lets': {
+        'iri': 'vm:HE/{row[CapabilityID].as_slug}',
+    },
+    'triples': [
+        ('{iri}', 'rdf:type', 'vm:HE/Capability'),
+        ('{iri}', 'vm:description', '{row[Description].as_text}'),
+        ('{iri}', 'vm:name', '{row[CapabilityID].as_text}'),
+        ('{iri}', 'skos:altLabel', '{row[Abbreviation].as_text}'),
+        # Present in ontology but not in sheet, seem to be using a standard
+        # hasInvolvement property added by capability2activity for now
+        # ('{iri}', 'vm:requiredFor', ''),
+    ],
+}

--- a/transforms/he/he_capability2activity.py
+++ b/transforms/he/he_capability2activity.py
@@ -1,0 +1,21 @@
+# use "Highways > 000 Data Ingest > capability2activity.xlsx"
+{
+    'sheet': 'cap2activity',
+    'lets': {
+        'iri': 'vm:HE/{row[CapabilityID].as_slug}-{row[ActivityID].as_slug}',
+        'parent_iri': 'vm:HE/{row[CapabilityID].as_slug}',
+        'activity_iri': 'vm:HE/{row[ActivityID].as_slug}',
+    },
+    'triples': [
+        ('{iri}', 'rdf:type', 'vm:HE/ActivityInvolvement'),
+        ('{iri}', 'vm:description', '{row[Description].as_text}'),
+        ('{iri}', 'vm:name',
+            '{row[CapabilityID].as_slug}-{row[ActivityID].as_slug}'),
+        ('{parent_iri}', 'vm:hasInvolvement', '{iri}'),
+        ('{iri}', 'vm:relatesTo', '{activity_iri}'),
+        ('{iri}', 'vm:activeLabel', '{row[ActiveInvolvement].as_text}'),
+        ('{iri}', 'vm:passiveLabel', '{row[PassiveInvolvement].as_text}'),
+        ('{iri}', 'vm:level', '{row[% Level].as_text}'),
+        ('{iri}', 'vm:primary', '{row[Primary].as_text}'),
+    ],
+}

--- a/transforms/he/he_itsystem.py
+++ b/transforms/he/he_itsystem.py
@@ -1,0 +1,23 @@
+# use "Highways > 000 Data Ingest > 20210311 activity2itsystem v3.xlsx"
+{
+    'sheet': 'itsystem',
+    'lets': {
+        'iri': 'vm:HE/itsystem-{row[ITSystemID].as_slug}',
+        'dp_iri': 'vm:/HE/deliverypartner-{row[DeliveryPartner].as_slug}'
+    },
+    'triples': [
+        ('{iri}', 'rdf:type',
+            'http://webprotege.stanford.edu/R9yHLGw3z6gILmTwQSizzdi'),
+        ('{iri}', 'vm:name', '{row[Shortname].as_text}'),
+        ('{iri}', 'vm:description', '{row[Description].as_text}'),
+        # possibly available via deliverypartner instead?
+        ('{dp_iri}', 'vm:supports', '{iri}'),
+        # columns present in sheet but unpopulated
+        # ('{iri}', 'vm:ownedBy',
+        #   'vm:/HE/person-{row[Person as Owner].as_slug}'),
+        # ('{iri}', 'vm:managedBy',
+        #   'vm:/HE/person-{row[Person as Manager].as_slug}'),
+        # not present in sheet
+        # ('{iri}', 'vm:sro', ''),
+    ],
+}

--- a/transforms/he/he_itsystem2activity.py
+++ b/transforms/he/he_itsystem2activity.py
@@ -1,0 +1,21 @@
+# use "Highways > 000 Data Ingest > 20210311 activity2itsystem v3.xlsx"
+{
+    'sheet': 'activity2itsystem',
+    'lets': {
+        'iri': 'vm:HE/{row[ITSystem].as_slug}-{row[ActivityID].as_slug}',
+        'parent_iri': 'vm:HE/itsystem-{row[ITSystem].as_slug}',
+        'activity_iri': 'vm:HE/{row[ActivityID].as_slug}',
+    },
+    'triples': [
+        ('{iri}', 'rdf:type', 'vm:HE/ActivityInvolvement'),
+        ('{iri}', 'vm:description', '{row[Description].as_text}'),
+        ('{iri}', 'vm:name',
+            '{row[ITSystem].as_slug}-{row[ActivityID].as_slug}'),
+        ('{parent_iri}', 'vm:hasInvolvement', '{iri}'),
+        ('{iri}', 'vm:relatesTo', '{activity_iri}'),
+        ('{iri}', 'vm:activeLabel', '{row[ActiveInvolvement].as_text}'),
+        ('{iri}', 'vm:passiveLabel', '{row[PassiveInvolvement].as_text}'),
+        ('{iri}', 'vm:level', '{row[% Level].as_text}'),
+        ('{iri}', 'vm:primary', '{row[Primary].as_text}'),
+    ],
+}

--- a/transforms/he/he_orgunit.py
+++ b/transforms/he/he_orgunit.py
@@ -1,0 +1,20 @@
+# use "Highways > 000 Ontology > highways_SMP_ingest.xlsx" -
+# this really just needs an additional column in the big sheet or
+# the orgunit2activity sheets
+{
+    'sheet': 'OrgUnit',
+    'lets': {
+        'iri': 'vm:HE/orgunit-{row[leader_staff_number].as_slug}',
+        'parent_iri': 'vm:HE/orgunit-{row[parent_org_staff_number].as_slug}',
+    },
+    'triples': [
+        ('{iri}', 'rdf:type',
+            'http://www.w3.org/ns/org#OrganisationalUnit'),
+        ('{iri}', 'vm:name', '{row[name].as_text}'),
+        ('{iri}', 'vm:ledBy',
+            'vm:HE/person-{row[leader_staff_number].as_text}'),
+        ('{iri}', 'vm:hasParentOrganization', '{parent_iri}'),
+        # Present in ontology, populated via orgunit2activity transform
+        # ('{iri}', 'vmhe:hasInvolvement', ''),
+    ],
+}

--- a/transforms/he/he_orgunit2activity.py
+++ b/transforms/he/he_orgunit2activity.py
@@ -1,0 +1,25 @@
+# use "Highways > 000 Data Ingest > 20210305 orgunit2actvity - master.xlsx"
+{
+    'sheet': 'org_unit2activity',
+    'lets': {
+        'iri': ('vm:HE/orgunit-{row[OrgUnitID].as_slug}'
+                '-{row[ActivityID].as_slug}'),
+        'parent_iri': 'vm:HE/orgunit-{row[OrgUnitID].as_slug}',
+        'activity_iri': 'vm:HE/{row[ActivityID].as_slug}',
+    },
+    'triples': [
+        ('{iri}', 'rdf:type', 'vm:HE/ActivityInvolvement'),
+        ('{iri}', 'vm:description', '{row[Description].as_text}'),
+        # name is just here so that I can see it in the explorer view for now
+        ('{iri}', 'vm:name',
+            'orgunit-{row[OrgUnitID].as_slug}-{row[ActivityID].as_slug}'),
+        ('{parent_iri}', 'vm:hasInvolvement', '{iri}'),
+        ('{iri}', 'vm:relatesTo', '{activity_iri}'),
+        ('{iri}', 'vm:activeLabel',
+            '{row[ActiveInvolvement].as_text}'),
+        ('{iri}', 'vm:passiveLabel',
+            '{row[PassiveInvolvement].as_text}'),
+        ('{iri}', 'vm:level', '{row[% Level].as_text}'),
+        ('{iri}', 'vm:primary', '{row[Primary].as_text}'),
+    ],
+}

--- a/transforms/he/he_person.py
+++ b/transforms/he/he_person.py
@@ -1,0 +1,16 @@
+
+# use "Highways > 000 Data Ingest > 20210307 org_units.xlsx"
+{
+    'sheet': 'person',
+    'lets': {
+        'iri': 'vm:HE/person-{row[staff_no].as_slug}',
+    },
+    'triples': [
+        ('{iri}', 'rdf:type',
+            'http://xmlns.com/foaf/0.1/Person'),
+        ('{iri}', 'vm:name', '{row[name].as_text}'),
+        ('{iri}', 'vm:worksIn', 'vm:HE/orgunit-{row[org_unit].as_slug}'),
+        # not available in current sheet
+        # ('{iri}', 'vm:position', '{row[Position].as_text}'),
+    ],
+}

--- a/transforms/he/he_project.py
+++ b/transforms/he/he_project.py
@@ -1,0 +1,17 @@
+# use "Highways > 000 Data Ingest > 20210310 activity2project.xlsx"
+# no guidelines for how to treat this in ontology so just wing it
+{
+    'sheet': 'project',
+    'lets': {
+        'iri': 'vm:HE/{row[project].as_slug}',
+    },
+    'triples': [
+        ('{iri}', 'rdf:type', 'vm:HE/Project'),
+        ('{iri}', 'vm:description', '{row[description].as_text}'),
+        ('{iri}', 'vm:name', '{row[project].as_text}'),
+        # staffNumber has vanished from the sheet
+        # ('{iri}', 'vm:hasOwner', 'vm:HE/person-{row[StaffNumber].as_slug}'),
+        ('{iri}', 'vm:hasType', '{row[Type].as_text}'),
+        ('{iri}', 'vm:hasStatus', '{row[Status].as_text}'),
+    ],
+}

--- a/transforms/he/he_project2activity.py
+++ b/transforms/he/he_project2activity.py
@@ -1,0 +1,21 @@
+# use "Highways > 000 Data Ingest > 20210310 activity2project.xlsx"
+{
+    'sheet': 'activity2project',
+    'lets': {
+        'iri': 'vm:HE/{row[Project].as_slug}-{row[ActivityID].as_slug}',
+        'parent_iri': 'vm:HE/orgunit-{row[Project].as_slug}',
+        'activity_iri': 'vm:HE/{row[ActivityID].as_slug}',
+    },
+    'triples': [
+        ('{iri}', 'rdf:type', 'vm:HE/ActivityInvolvement'),
+        ('{iri}', 'vm:description', '{row[Description].as_text}'),
+        ('{iri}', 'vm:name',
+            '{row[Project].as_slug}-{row[ActivityID].as_slug}'),
+        ('{parent_iri}', 'vm:hasInvolvement', '{iri}'),
+        ('{iri}', 'vm:relatesTo', '{activity_iri}'),
+        ('{iri}', 'vm:activeLabel', '{row[ActiveInvolvement].as_text}'),
+        ('{iri}', 'vm:passiveLabel', '{row[PassiveInvolvement].as_text}'),
+        ('{iri}', 'vm:level', '{row[% Level].as_text}'),
+        ('{iri}', 'vm:primary', '{row[Primary].as_text}'),
+    ],
+}

--- a/transforms/hwx_views.py
+++ b/transforms/hwx_views.py
@@ -1,7 +1,9 @@
 {
     'data': [
-        ('activity', '', 'Activity View', 'a=HE/Activity'),
-        ('org', 'org', 'Organisation View',
+        ('activity', 'activity', '', 'Activity View', 'a=HE/Activity'),
+        ('org', 'org', 'org', 'Organisation View',
+            'a=org:OrganisationalUnit'),
+        ('orgpeople', 'org', 'org', 'Organisation + People View',
             'a=org:OrganisationalUnit+foaf:Person'),
     ],
     'lets': {
@@ -10,12 +12,12 @@
     },
     'triples': [
         ('{iri}', 'rdf:type', 'vm:View'),
-        ('{iri}', 'vm:name', '{row[2]}'),
+        ('{iri}', 'vm:name', '{row[3]}'),
         ('{iri}', 'vm:usesMapTiles',
             'https://opatlas-live.s3.amazonaws.com/hwx/{version}/overlays/'
-            '{row[1].as_text}/{{z}}-{{x}}-{{y}}.png#background:#fff'),
-        ('{iri}', 'vm:useFilters', '{row[3]}'),
+            '{row[2].as_text}/{{z}}-{{x}}-{{y}}.png#background:#fff'),
+        ('{iri}', 'vm:useFilters', '{row[4]}'),
         ('{iri}', 'vm:asOrdinal', '{n}'),
-        ('{iri}', 'vm:comment', '{row[0]}'),
+        ('{iri}', 'vm:comment', '{row[1]}'),
     ],
 }


### PR DESCRIPTION
* I have tried to match the ontology as closely as possible, including stub values where no values exist in the source sheets.
* This pulls its data from five different workbooks, a situation that is only going to get worse as more classes are added. The relevant workbook is noted at the top of each transform. 
* The command to build the triples is extremely fun:

```python3 -m sheet_to_triples --book '../books/highways_SMP_ingest_20210310.xlsx' --book '../books/20210310 activity2project v2.xlsx' --book '../books/20210305 org_unit2activity - master.xlsx' --book '../books/20210311 activity2itsystem v3.xlsx' --book '../books/capability2activity.xlsx' --add-graph ../turtle.owl --model ../he_empty.json hwx_labels hwx_org_labels he_class_icons hwx_views he/he_orgunit he/he_orgunit2activity he/he_project he/he_project2activity he/he_itsystem he/he_itsystem2activity he/he_capability he/he_capability2activity he/he_person --verbose```

* This is adding enough transforms that I think it warrants its own folder, if only to separate it out from earlier `he` transforms. 
