### PR TITLE
Add multiple linking for predicates and multiple transforms in 1 file

### DIFF
--- a/sheet_to_triples/__main__.py
+++ b/sheet_to_triples/__main__.py
@@ -41,10 +41,13 @@ def parse_args(argv):
     parser.add_argument(
         '--verbose', action='store_true', help='show details as turtle')
     parser.add_argument(
+        '--spec', action='extend', type=trans.Transform.from_spec,
+        help='add multiple transforms from a single spec file')
+    parser.add_argument(
         'transform', nargs='*', type=trans.Transform.from_name,
         help='names of any transforms to run')
     args = parser.parse_args(argv[1:])
-
+    args.transform.extend(args.spec)
     if not args.book:
         need_book = set(tf.name for tf in args.transform if tf.uses_sheet())
         if need_book:

--- a/sheet_to_triples/run.py
+++ b/sheet_to_triples/run.py
@@ -42,6 +42,8 @@ class Runner:
             # Note that model is updated but basis graph is not
             if self.model:
                 rdf.update_model_terms(self.model, triples)
+                if tf.non_uniques:
+                    rdf.update_non_uniques(self.model, tf.non_uniques)
 
         if self.model:
             rdf.normalise_model(self.model, self.ns, self.verbose)

--- a/sheet_to_triples/trans.py
+++ b/sheet_to_triples/trans.py
@@ -45,7 +45,15 @@ def _as_obj(formatter, template, params):
 class Transform:
     """Class to load and process functional row to RDF transformation."""
 
-    __slots__ = ('name', 'data', 'sheet', 'lets', 'queries', 'triples')
+    __slots__ = (
+        'name',
+        'data',
+        'sheet',
+        'lets',
+        'queries',
+        'triples',
+        'non_unique',
+    )
 
     def __init__(self, name, details):
         self.name = name
@@ -60,6 +68,19 @@ class Transform:
         path = os.path.join('transforms', name + '.py')
         with open(path, 'r', encoding='utf-8') as f:
             return cls(name, ast.literal_eval(f.read()))
+
+    @classmethod
+    def from_spec(cls, name):
+        path = os.path.join('transforms', name + '.py')
+        with open(path, 'r', encoding='utf-8') as f:
+            for t in ast.literal_eval(f.read()):
+                yield cls(name, t)
+
+    @property
+    def non_uniques(self):
+        non_uniques = getattr(self, 'non_unique', [])
+        # would we ever want to template this and use _as_iri instead?
+        return [rdf.from_qname(pred) for pred in non_uniques]
 
     def uses_sheet(self):
         return hasattr(self, 'sheet')


### PR DESCRIPTION
This got hacky as a consequence of the way the code is currently structured, along with my knowing just enough about `argparse` to be dangerous.

* Multiple linking is achieved by adding a new `non_unique` property to a transform, which is a list of predicates. This list is propagated up and attached to the model, with new `non_unique` attributes being added with each transform. At the `normalise_model` step, any predicates in this list are deduped according to a unique combination of `subj, pred, obj` instead of `subj, pred`.
* Meanwhile I have been wrestling with a dataset that requires me to extract data from four different tabs in the source book. Ordinarily this would require adding four different transforms, which quickly becomes a logistical nightmare as we deal with more workbooks -- I want a one transform file -> one workbook relationship instead of one transform file -> one workbook tab. So I've introduced the concept of a `--spec` to the command line, which is a file containing an array of transforms instead of a single transform. Any transforms extracted from `args.spec` are bolted onto the end of the existing `args.transforms` object and then treated normally from then on.

I'll do some cleanup tomorrow morning (this is probably going to fail gating), but this is enough for a first-pass review.