### PR TITLE
Add transform spec for performance measures

### DIFF
--- a/sheet_to_triples/field.py
+++ b/sheet_to_triples/field.py
@@ -86,6 +86,17 @@ class Cell:
         # TODO: Check expected order (leaflet only is backwards?)
         return f'[{lat}, {lng}]'
 
+    @property
+    def as_date(self):
+        return _must(self._value.strftime('%Y-%m-%d'))
+
+    @property
+    def as_date_or_text(self):
+        try:
+            return self.as_date
+        except AttributeError:
+            return self.as_text
+
 
 class Row:
     """Group of fields keyed by name."""

--- a/transforms/he/he_perfmeasures.py
+++ b/transforms/he/he_perfmeasures.py
@@ -1,0 +1,108 @@
+# uses Highways > 000 Data Ingest > 20210323 performance measures.xlsx
+
+# defines properties and relationships for the following classes:
+# * Desired Result (which may be assessed by many Performance Measures)
+# * Performance Measure (which may be measured by many Recorded Measures)
+# * Recorded Measure (which may link to many Single Recorded Measures)
+# * Single Recorded Measure
+# * Unit
+[
+    {
+        'sheet': 'PM Results',
+        'non_unique': ['vm:hasRecordedMeasure'],
+        'lets': {
+            'rec_iri': 'vm:HE/{row[PM number (VM)].as_slug}',
+            'ind_rec_iri': ('vm:HE/{row[PM number (VM)].as_slug}'
+                            '-{row[Time of measure].as_slug}'
+                            '-{row[Date of measure].as_date_or_text}'),
+            'unit_iri': 'vm:HE/unit-{row[Unit of measure].as_slug}',
+        },
+        # define 3 classes from this sheet
+        'triples': [
+            # Recorded Measure - this is an object to attach Single Recorded
+            # Measures to, there will be many dupes that get deduped later
+            ('{rec_iri}', 'rdf:type', 'vm:RecordedMeasure'),
+            ('{rec_iri}', 'vm:name', '{row[PM Title].as_text}'),
+            ('{rec_iri}', 'vm:hasRecord', '{ind_rec_iri}'),
+            # Single Recorded Measure - an invented class containing data for
+            # a single record of the Recorded Measure at a fixed point in time
+            ('{ind_rec_iri}', 'rdf:type', 'vm:SingleRecordedMeasure'),
+            ('{ind_rec_iri}', 'vm:name',
+                ('{row[PM Title].as_text} - '
+                 '{row[Time of measure].as_text} '
+                 '{row[Date of measure].as_date_or_text}')),
+            ('{ind_rec_iri}', 'vm:records', '{row[Measure].as_text}'),
+            ('{ind_rec_iri}', 'vm:takenAt',
+                '{row[Date of measure].as_date_or_text}'),
+            ('{ind_rec_iri}', 'vm:timeOfMeasure',
+                '{row[Time of measure].as_text}'),
+            ('{ind_rec_iri}', 'vm:measuredIn',
+                'vm:HE/unit-{row[Unit of measure].as_slug}'),
+            # Unit
+            ('{unit_iri}', 'rdf:type', 'vm:Unit'),
+            ('{unit_iri}', 'vm:name', '{row[Unit of measure].as_text}'),
+        ],
+    },
+    {
+        'sheet': 'Performance Measures (PM)',
+        'lets': {
+            'rec_iri': 'vm:HE/{row[PM number (VM)].as_slug}',
+        },
+        'triples': [
+            ('{rec_iri}', 'vm:description', '{row[Description].as_text}'),
+        ],
+    },
+    {
+        # This data model is a bit confusing - in the hierarchy of data the
+        # sheet's concept of a Metric actually occupies the corresponding
+        # position of the ontology's Performance Measure, and the sheet's
+        # Performance Measure is an ontology Recorded Measure
+        'sheet': 'Metrics2PM ',
+        'non_unique': ['vm:measures', 'vm:hasRecordedMeasure'],
+        'lets': {
+            'pm_iri': 'vm:HE/{row[MET number (VM)].as_slug}',
+            'rec_iri': 'vm:HE/{row[Linked to PM number].as_slug}',
+            'dr_iri': ('vm:HE/{row[Performance Specification / Desired Result]'
+                       '.as_slug}')
+        },
+        'triples': [
+            # Desired Result - this should link up with top level definitions
+            # from the AI export
+            ('{dr_iri}', 'rdf:type', 'vm:DesiredResult'),
+            ('{dr_iri}', 'vm:name',
+                '{row[AI_desired_result].as_text}'),
+            ('{pm_iri}', 'rdf:type',
+                'http://webprotege.stanford.edu/Rr60siMdu9IEvdag4DhF7M'),
+            ('{pm_iri}', 'vm:name', '{row[Title].as_text}'),
+            ('{pm_iri}', 'vm:hasRecordedMeasure', '{rec_iri}'),
+            ('{pm_iri}', 'vm:measures', '{dr_iri}'),
+            # Not in sheet
+            # Customer (subclass of Orgunit)
+            # ('{iri}', 'vm:providesValueTo', ''),
+            # Stakeholder (subclass of Orgunit)
+            # ('{iri}', 'vm:ofInterestTo', ''),
+        ],
+    },
+    {
+        'sheet': 'HE Metrics',
+        'allow_empty_subject': True,
+        'lets': {
+            'pm_iri': 'vm:HE/{row[MET number (VM)].as_slug}'
+        },
+        'triples': [
+            ('{pm_iri}', 'vm:description', '{row[Description]}'),
+        ],
+    },
+    {
+        # Can link from PM to activity but not from Desired Result to activity
+        # as the ontology specifies
+        'sheet': 'Metric_2_activity',
+        'lets': {
+            'pm_iri': 'vm:HE/{row[MET number (VM)].as_slug}',
+            'activity_iri': 'vm:HE/{row[Activity].as_slug}'
+        },
+        'triples': [
+            ('{activity_iri}', 'vm:leadsTo', '{pm_iri}'),
+        ],
+    }
+]


### PR DESCRIPTION
Previous transforms have been relatively simple. This one was definitely not. We have many ontology classes encapsulated in this sheet with a complex set of relationships that wasn't an exact match for the source data -- there are some conceptual differences and broken linkages. I am not sure this is usable as-is as none of these objects are visible or easily reachable from things that are.

I'll write up some notes tomorrow morning so that I haven't forgotten everything by the time we do the post-mortem next week (hopefully).

Other misc changes:

* There is an `as_date_or_text` property in `field` now -- this is to try and deal with a column containing mixed date formats where Excel has helpfully converted half of it to a full yyyy/mm/dd date (which is ingested as a Python datetime and needs bits chopping off to be sane) and the other half remains as the original text.
* Some other changes to stringifying that duplicate changes from the other PR, as discussed.
* A fix for specs falling over when trying to dump the model back out to JSON.