### PR TITLE
Change and use new non_unique transform option

### DIFF
--- a/sheet_to_triples/rdf.py
+++ b/sheet_to_triples/rdf.py
@@ -107,10 +107,6 @@ def update_model_terms(model, triples):
         dict(subj=str(s), pred=str(p), obj=str(o)) for s, p, o in triples)
 
 
-def update_non_uniques(model, non_uniques):
-    model.setdefault('non_uniques', set()).update(non_uniques)
-
-
 def _with_int_maybe(iri):
     try:
         prefix, maybe_int = iri.rsplit('/', 1)
@@ -125,9 +121,8 @@ def _to_key(t, non_uniques):
     return t['subj'], t['pred']
 
 
-def normalise_model(model, ns, verbose):
+def normalise_model(model, ns, non_uniques, verbose):
     terms = model['terms']
-    non_uniques = model.get('non_uniques', set())
     # Record subjects that have been renamed so triples can be moved over
     sameAs = rdflib.namespace.OWL.sameAs.toPython()
     same = {}

--- a/sheet_to_triples/run.py
+++ b/sheet_to_triples/run.py
@@ -23,6 +23,7 @@ class Runner:
             self.graph = rdf.graph_from_model(model)
         else:
             self.graph = rdf.graph_from_triples(())
+        self.non_unique = set()
         self.verbose = verbose
 
     @classmethod
@@ -34,6 +35,7 @@ class Runner:
     def run(self, transforms):
         for tf in transforms:
             triples = tf.process(self.graph, self._iter_data(tf))
+            self.non_unique.update(tf.get_non_uniques(self.ns))
 
             if self.verbose:
                 triples = list(triples)
@@ -42,11 +44,10 @@ class Runner:
             # Note that model is updated but basis graph is not
             if self.model:
                 rdf.update_model_terms(self.model, triples)
-                if tf.non_uniques:
-                    rdf.update_non_uniques(self.model, tf.non_uniques)
 
         if self.model:
-            rdf.normalise_model(self.model, self.ns, self.verbose)
+            rdf.normalise_model(
+                self.model, self.ns, self.non_unique, self.verbose)
 
     @property
     def ns(self):

--- a/sheet_to_triples/trans.py
+++ b/sheet_to_triples/trans.py
@@ -76,11 +76,10 @@ class Transform:
             for t in ast.literal_eval(f.read()):
                 yield cls(name, t)
 
-    @property
-    def non_uniques(self):
-        non_uniques = getattr(self, 'non_unique', [])
+    def get_non_uniques(self, ns):
+        non_unique = getattr(self, 'non_unique', ())
         # would we ever want to template this and use _as_iri instead?
-        return [rdf.from_qname(pred) for pred in non_uniques]
+        return set(rdf.from_qname(q, ns).toPython() for q in non_unique)
 
     def uses_sheet(self):
         return hasattr(self, 'sheet')

--- a/transforms/he/he_capability2activity.py
+++ b/transforms/he/he_capability2activity.py
@@ -6,6 +6,7 @@
         'parent_iri': 'vm:HE/{row[CapabilityID].as_slug}',
         'activity_iri': 'vm:HE/{row[ActivityID].as_slug}',
     },
+    'non_unique': ['vm:hasInvolvement'],
     'triples': [
         ('{iri}', 'rdf:type', 'vm:HE/ActivityInvolvement'),
         ('{iri}', 'vm:description', '{row[Description].as_text}'),

--- a/transforms/he/he_itsystem.py
+++ b/transforms/he/he_itsystem.py
@@ -5,6 +5,7 @@
         'iri': 'vm:HE/itsystem-{row[ITSystemID].as_slug}',
         'dp_iri': 'vm:/HE/deliverypartner-{row[DeliveryPartner].as_slug}'
     },
+    'non_unique': ['vm:supports'],
     'triples': [
         ('{iri}', 'rdf:type',
             'http://webprotege.stanford.edu/R9yHLGw3z6gILmTwQSizzdi'),

--- a/transforms/he/he_itsystem2activity.py
+++ b/transforms/he/he_itsystem2activity.py
@@ -6,6 +6,7 @@
         'parent_iri': 'vm:HE/itsystem-{row[ITSystem].as_slug}',
         'activity_iri': 'vm:HE/{row[ActivityID].as_slug}',
     },
+    'non_unique': ['vm:hasInvolvement'],
     'triples': [
         ('{iri}', 'rdf:type', 'vm:HE/ActivityInvolvement'),
         ('{iri}', 'vm:description', '{row[Description].as_text}'),

--- a/transforms/he/he_orgunit2activity.py
+++ b/transforms/he/he_orgunit2activity.py
@@ -7,6 +7,7 @@
         'parent_iri': 'vm:HE/orgunit-{row[OrgUnitID].as_slug}',
         'activity_iri': 'vm:HE/{row[ActivityID].as_slug}',
     },
+    'non_unique': ['vm:hasInvolvement'],
     'triples': [
         ('{iri}', 'rdf:type', 'vm:HE/ActivityInvolvement'),
         ('{iri}', 'vm:description', '{row[Description].as_text}'),

--- a/transforms/he/he_project2activity.py
+++ b/transforms/he/he_project2activity.py
@@ -6,6 +6,7 @@
         'parent_iri': 'vm:HE/orgunit-{row[Project].as_slug}',
         'activity_iri': 'vm:HE/{row[ActivityID].as_slug}',
     },
+    'non_unique': ['vm:hasInvolvement'],
     'triples': [
         ('{iri}', 'rdf:type', 'vm:HE/ActivityInvolvement'),
         ('{iri}', 'vm:description', '{row[Description].as_text}'),


### PR DESCRIPTION
Rework how the information about predicates that can appear multiple
times gets passed around. Avoids putting it on model, which is the
external interface, and instead track on the runner.

Mark some HE transform predicates as non_unique.