### PR TITLE
Add allow_empty_subject option for transforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,10 +72,11 @@ The top level attributes of a transform are:
 
   Output triples to create and be added to model.
 * `non_unique: List[str_predicate, ...]`
-  
-  Normally triples are assumed unique for the first two items in each triple (subject predicate). If multiple triples have the same subject-predicate pairing, the oldest triple will be 
-  dropped and replaced with the newest one. By adding a predicate to `non_unique` it is treated as non-unique, and only duplicates of the full `(subject, predicate, object)` triple will
-  be dropped.
+
+  Normally triples are assumed unique for the first two items in each triple (subject predicate). If multiple triples have the same subject-predicate pairing, the oldest triple will be dropped and replaced with the newest one. By adding a predicate to `non_unique` it is treated as non-unique, and only duplicates of the full `(subject, predicate, object)` triple will be dropped.
+* `allow_empty_subject: bool`
+
+  By default, an exception is raised if any triple does not have a subject. If this flag is set to `True` instead that triple is just omitted from the output.
 
 
 ## Findings

--- a/transforms/he/he_capability2activity.py
+++ b/transforms/he/he_capability2activity.py
@@ -3,16 +3,16 @@
     'sheet': 'cap2activity',
     'lets': {
         'iri': 'vm:HE/{row[CapabilityID].as_slug}-{row[ActivityID].as_slug}',
-        'parent_iri': 'vm:HE/{row[CapabilityID].as_slug}',
         'activity_iri': 'vm:HE/{row[ActivityID].as_slug}',
     },
+    'allow_empty_subject': True,
     'non_unique': ['vm:hasInvolvement'],
     'triples': [
         ('{iri}', 'rdf:type', 'vm:HE/ActivityInvolvement'),
         ('{iri}', 'vm:description', '{row[Description].as_text}'),
         ('{iri}', 'vm:name',
             '{row[CapabilityID].as_slug}-{row[ActivityID].as_slug}'),
-        ('{parent_iri}', 'vm:hasInvolvement', '{iri}'),
+        ('vm:HE/{row[CapabilityID].as_slug}', 'vm:hasInvolvement', '{iri}'),
         ('{iri}', 'vm:relatesTo', '{activity_iri}'),
         ('{iri}', 'vm:activeLabel', '{row[ActiveInvolvement].as_text}'),
         ('{iri}', 'vm:passiveLabel', '{row[PassiveInvolvement].as_text}'),

--- a/transforms/he/he_itsystem.py
+++ b/transforms/he/he_itsystem.py
@@ -3,8 +3,8 @@
     'sheet': 'itsystem',
     'lets': {
         'iri': 'vm:HE/itsystem-{row[ITSystemID].as_slug}',
-        'dp_iri': 'vm:/HE/deliverypartner-{row[DeliveryPartner].as_slug}'
     },
+    'allow_empty_subject': True,
     'non_unique': ['vm:supports'],
     'triples': [
         ('{iri}', 'rdf:type',
@@ -12,7 +12,8 @@
         ('{iri}', 'vm:name', '{row[Shortname].as_text}'),
         ('{iri}', 'vm:description', '{row[Description].as_text}'),
         # possibly available via deliverypartner instead?
-        ('{dp_iri}', 'vm:supports', '{iri}'),
+        ('vm:/HE/deliverypartner-{row[DeliveryPartner].as_slug}',
+            'vm:supports', '{iri}'),
         # columns present in sheet but unpopulated
         # ('{iri}', 'vm:ownedBy',
         #   'vm:/HE/person-{row[Person as Owner].as_slug}'),


### PR DESCRIPTION
To supersede a hack required for HE transforms due to optional links
specified in columns. A subject must still exist (no blank nodes)
however the transform is allowed to continue if a triple lacking a
subject would have been created.

Move iri creation inline for two transforms where those triples are
optional, to be more explicit about that property.