### PR TITLE
Add `skip_empty_rows` option to transforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,9 @@ The top level attributes of a transform are:
 * `allow_empty_subject: bool`
 
   By default, an exception is raised if any triple does not have a subject. If this flag is set to `True` instead that triple is just omitted from the output.
+* `skip_empty_rows: bool`
+
+  By default the first empty row found in a sheet is treated as the EOF and row parsing will halt if one is encountered. If this flag is set to `True` then empty rows will be skipped over instead and the entire sheet will be parsed.
 
 
 ## Findings

--- a/sheet_to_triples/run.py
+++ b/sheet_to_triples/run.py
@@ -56,7 +56,8 @@ class Runner:
     def _iter_data(self, tf):
         if self.books and tf.uses_sheet():
             row_iter = xl.iter_sheet(self.books, tf.sheet)
-            return xl.as_rows(row_iter, tf.required_rows())
+            return xl.as_rows(
+                row_iter, tf.required_rows(), tf.skip_empty_rows)
         return (field.Row(r) for r in getattr(tf, 'data', ()))
 
     @staticmethod

--- a/sheet_to_triples/trans.py
+++ b/sheet_to_triples/trans.py
@@ -65,10 +65,12 @@ class Transform:
         'triples',
         'non_unique',
         'allow_empty_subject',
+        'skip_empty_rows',
     )
 
     def __init__(self, name, details):
         self.name = name
+        self.skip_empty_rows = False
         for k in details:
             setattr(self, k, details[k])
 

--- a/sheet_to_triples/xl.py
+++ b/sheet_to_triples/xl.py
@@ -29,11 +29,14 @@ def iter_sheet(books, sheet_name):
     raise ValueError(f'sheet {sheet_name!r} not found') from last_err
 
 
-def as_rows(row_iter, required_headers):
+def as_rows(row_iter, required_headers, skip_empty_rows):
     header_values = advance_headers(row_iter, required_headers)
     n_from_h = {h: i for i, h in reversed(list(enumerate(header_values)))}
     for row in row_iter:
+        # treat blank row as EOF if skip_empty_rows not True
         if all(not r.value for r in row):
+            if skip_empty_rows:
+                continue
             return
         yield field.Row({h: row[n_from_h[h]].value for h in required_headers})
 

--- a/transforms/he/he_orgunit2activity.py
+++ b/transforms/he/he_orgunit2activity.py
@@ -7,6 +7,8 @@
         'parent_iri': 'vm:HE/orgunit-{row[OrgUnitID].as_slug}',
         'activity_iri': 'vm:HE/{row[ActivityID].as_slug}',
     },
+    'allow_empty_subject': True,
+    'skip_empty_rows': True,
     'non_unique': ['vm:hasInvolvement'],
     'triples': [
         ('{iri}', 'rdf:type', 'vm:HE/ActivityInvolvement'),


### PR DESCRIPTION
Split it out from `allow_empty_subject` because they're not really the same thing and I deplore having a fuzzy higher-level option which no fine control.

The `_skip_empty_rows` spelling on the transform property bugs me but I'm not sure how else to do this with `__slots__`.