### PR TITLE
Allow `--book` to take a directory path containing workbooks

### DIFF
--- a/sheet_to_triples/__main__.py
+++ b/sheet_to_triples/__main__.py
@@ -4,6 +4,7 @@
 """Convert tabular data into triples."""
 
 import argparse
+import os
 import sys
 
 from . import (
@@ -20,10 +21,24 @@ PURGE_MAP = {
 }
 
 
+def _is_book_path(path):
+    return path.endswith(('.xls', '.xlsx'))
+
+
+def _parse_book_path(path):
+    if os.path.isdir(path):
+        for root, dirs, files in os.walk(path):
+            for filepath in filter(_is_book_path, files):
+                yield os.path.join(root, filepath)
+            return
+    else:
+        yield path
+
+
 def parse_args(argv):
     parser = argparse.ArgumentParser(argv[0], description=__doc__)
     parser.add_argument(
-        '--book', action='append',
+        '--book', action='extend', type=_parse_book_path,
         help='paths to any spreadsheet files to load')
     parser.add_argument(
         '--add-graph', help='path to existing graph to add to model')


### PR DESCRIPTION
The number of workbooks involved in the HE transforms is becoming unmanageably large when you have to explicitly state the filepath for each one every time you run `sheet_to_triples`. Allowing `--book` to take a directory path instead which it can look inside to find workbooks makes it much simpler.

This does increase the risk of collisions in sheet names as by default all books inside the target directory will be iterated through in alphabetical order until the first matching sheet is found, but I have another change coming that addresses that issue.