### PR TITLE
Transforms may now specify the workbook to pull sheet data from

### DIFF
--- a/sheet_to_triples/__main__.py
+++ b/sheet_to_triples/__main__.py
@@ -20,6 +20,7 @@ PURGE_MAP = {
     'issues': rdf.relates_issue,
 }
 
+
 def _is_book_path(path):
     return path.endswith(('.xls', '.xlsx'))
 
@@ -32,8 +33,8 @@ def _parse_book_path(path):
             return
     else:
         yield path
-            
-    
+
+
 def parse_args(argv):
     parser = argparse.ArgumentParser(argv[0], description=__doc__)
     parser.add_argument(

--- a/sheet_to_triples/__main__.py
+++ b/sheet_to_triples/__main__.py
@@ -20,7 +20,6 @@ PURGE_MAP = {
     'issues': rdf.relates_issue,
 }
 
-
 def _is_book_path(path):
     return path.endswith(('.xls', '.xlsx'))
 
@@ -33,8 +32,8 @@ def _parse_book_path(path):
             return
     else:
         yield path
-
-
+            
+    
 def parse_args(argv):
     parser = argparse.ArgumentParser(argv[0], description=__doc__)
     parser.add_argument(

--- a/sheet_to_triples/trans.py
+++ b/sheet_to_triples/trans.py
@@ -59,6 +59,7 @@ class Transform:
     __slots__ = (
         'name',
         'data',
+        'book',
         'sheet',
         'lets',
         'queries',
@@ -70,6 +71,7 @@ class Transform:
 
     def __init__(self, name, details):
         self.name = name
+        self.book = None
         self.skip_empty_rows = False
         for k in details:
             setattr(self, k, details[k])


### PR DESCRIPTION
(I was kind of hoping I could avoid including the book-directory-parsing code here as the entire point was to isolate each feature in its own PR.)

Allow a transform to explicitly specify the workbook filename that it should pull its sheet data from. This is a necessary change as we're now using something like 12 workbooks in the HE data ingest and I would really like to eliminate the possibility of sheet name collisions, however it comes with the following drawbacks:

* Every time a new workbook version is created with updated date or version number in the workbook filename, the transform also needs to be updated, which is more maintenance overhead. However I was logging the workbook names in comments to keep track of them all anyway so in reality it's not actually more work.
* My implementation of this is _super_ hacky, as we were previously dumping the filename data the moment the runner class was instantiated. Also `xl.iter_sheet` wants an iterable full of workbooks and so I just pass it the target workbook wrapped in a single-item list.  

Breaking the paradigm of "a Runner takes an iterable of Book objects" and replacing it with this weird dict thing is pretty bad, but I'm not sure how else to do it.