### PR TITLE
Remove `--spec` and infer from file data instead.

### DIFF
--- a/sheet_to_triples/__main__.py
+++ b/sheet_to_triples/__main__.py
@@ -40,7 +40,7 @@ def _parse_transform_list(path):
     transforms = []
     with open(path, 'r') as f:
         for transform in f.read().splitlines():
-            transforms.extend(trans.Transform.from_name(transform))
+            transforms.extend(trans.Transform.iter_from_name(transform))
     return transforms
 
 
@@ -68,7 +68,7 @@ def parse_args(argv):
         '--from-list', type=_parse_transform_list,
         help='add multiple transforms from a text file of transform names')
     parser.add_argument(
-        'transform', nargs='*', type=trans.Transform.from_name,
+        'transform', nargs='*', type=trans.Transform.iter_from_name,
         help='names of any transforms to run')
     args = parser.parse_args(argv[1:])
     # need to flatten this slightly awkward way as action=extend doesn't work

--- a/sheet_to_triples/trans.py
+++ b/sheet_to_triples/trans.py
@@ -80,7 +80,7 @@ class Transform:
         return f'<{self.__class__.__name__} {self.name!r}>'
 
     @classmethod
-    def from_name(cls, name):
+    def iter_from_name(cls, name):
         path = os.path.join('transforms', name + '.py')
         with open(path, 'r', encoding='utf-8') as f:
             transform = ast.literal_eval(f.read())

--- a/sheet_to_triples/trans.py
+++ b/sheet_to_triples/trans.py
@@ -83,14 +83,12 @@ class Transform:
     def from_name(cls, name):
         path = os.path.join('transforms', name + '.py')
         with open(path, 'r', encoding='utf-8') as f:
-            return cls(name, ast.literal_eval(f.read()))
-
-    @classmethod
-    def from_spec(cls, name):
-        path = os.path.join('transforms', name + '.py')
-        with open(path, 'r', encoding='utf-8') as f:
-            for t in ast.literal_eval(f.read()):
-                yield cls(name, t)
+            transform = ast.literal_eval(f.read())
+            if isinstance(transform, list):
+                for t in transform:
+                    yield cls(name, t)
+            else:
+                yield cls(name, transform)
 
     def get_non_uniques(self, ns):
         non_unique = getattr(self, 'non_unique', ())

--- a/transforms/he/transforms_list.txt
+++ b/transforms/he/transforms_list.txt
@@ -1,0 +1,14 @@
+he/he_activity_type
+he/he_capability
+he/he_capability2activity
+he/he_data_asset
+he/he_itsystem
+he/he_itsystem2activity
+he/he_orgunit
+he/he_orgunit2activity
+he/he_perfmeasures
+he/he_person
+he/he_project
+he/he_project2activity
+he_class_icons
+hwx_views


### PR DESCRIPTION
Add `--from-list` option for reading transform names from list file.

You were right about `--spec`, having to remember which transforms are specs and which are not is too awkward, so infer it via type checking instead (even if the `yield` spelling is also very awkward).

Initially tried to add functionality to read a directory full of transforms, but this is a) surprisingly difficult and b) not precise enough, you may not want to read every transform inside the `he` directory for example. The simpler, cruder solution is actually better here: have a text file full of transform names that you can pass via `--from-list`.

With this change the insanely complicated command for running the HE transforms becomes something like:

```
python -m sheet-to-triples --add-model model.owl --book ../<synced 000 Data Ingest folder> --from-list transforms/he/transforms.txt  hwx_labels hwx_org_labels
```

This is substantially less brittle. The last area that should be looked at at some point is versioning `000 Data Ingest` each time we do a push so that we know what we have and can revert if necessary, but we push the model infrequently enough that we can just do a manual dump of the folder.