### PR TITLE
Add means to take non-unique from past transforms

### DIFF
--- a/sheet_to_triples/__main__.py
+++ b/sheet_to_triples/__main__.py
@@ -68,6 +68,9 @@ def parse_args(argv):
         '--from-list', type=_parse_transform_list,
         help='add multiple transforms from a text file of transform names')
     parser.add_argument(
+        '--non-unique-from', type=_parse_transform_list,
+        help='load non unique triple properties from list of past transforms')
+    parser.add_argument(
         'transform', nargs='*', type=trans.Transform.iter_from_name,
         help='names of any transforms to run')
     args = parser.parse_args(argv[1:])
@@ -93,6 +96,8 @@ def main(argv):
         rdf.update_model_terms(runner.model, iter(runner.graph))
 
     with debug.context(args.debug):
+        if args.non_unique_from:
+            runner.use_non_uniques(args.non_unique_from)
         if args.transform:
             runner.run(args.transform)
             if runner.model:

--- a/sheet_to_triples/run.py
+++ b/sheet_to_triples/run.py
@@ -36,6 +36,10 @@ class Runner:
         model = args.model and cls.load_model(args.model)
         return cls(book, model, args.purge_except, args.verbose)
 
+    def use_non_uniques(self, old_transforms):
+        for tf in old_transforms:
+            self.non_unique.update(tf.get_non_uniques(self.ns))
+
     def run(self, transforms):
         for tf in transforms:
             triples = tf.process(self.graph, self._iter_data(tf))


### PR DESCRIPTION
When running a transform in multiple stages, all subsequent steps
require knowing which triples should not be sanitised out.