### PR TITLE
Add flag to not resolve aliases

### DIFF
--- a/sheet_to_triples/__main__.py
+++ b/sheet_to_triples/__main__.py
@@ -62,6 +62,9 @@ def parse_args(argv):
         type=PURGE_MAP.get, default='none',
         help='Use named rule to remove some triples from existing model')
     parser.add_argument(
+        '--no-resolve-same', action='store_false', dest='resolve_same',
+        help='keep triples that mark same identity in output model')
+    parser.add_argument(
         '--debug', action='store_true', help='debug interactively any error')
     parser.add_argument(
         '--verbose', action='store_true', help='show details as turtle')

--- a/sheet_to_triples/run.py
+++ b/sheet_to_triples/run.py
@@ -16,7 +16,7 @@ from . import (
 class Runner:
     """Encapsulation of new data, existing model, and transform running."""
 
-    def __init__(self, books, model, purge_except, verbose):
+    def __init__(self, books, model, purge_except, resolve_same, verbose):
         self.books = books
         self.model = model
         if model:
@@ -25,6 +25,7 @@ class Runner:
         else:
             self.graph = rdf.graph_from_triples(())
         self.non_unique = set()
+        self.resolve_same = resolve_same
         self.verbose = verbose
 
     @classmethod
@@ -34,7 +35,8 @@ class Runner:
         else:
             book = dict()
         model = args.model and cls.load_model(args.model)
-        return cls(book, model, args.purge_except, args.verbose)
+        return cls(
+            book, model, args.purge_except, args.resolve_same, args.verbose)
 
     def use_non_uniques(self, old_transforms):
         for tf in old_transforms:
@@ -55,7 +57,8 @@ class Runner:
 
         if self.model:
             rdf.normalise_model(
-                self.model, self.ns, self.non_unique, self.verbose)
+                self.model, self.ns, self.non_unique, self.resolve_same,
+                self.verbose)
 
     @property
     def ns(self):


### PR DESCRIPTION
For use when a first parse declares multiple identities for an
individual which a second pass needs to resolve against prior to
removing.

An input data sheet can then have old and redundant identities which
label creation can use without needing complex lookup heuristics.