### PR TITLE
Add RIS3 risk map data transform

### DIFF
--- a/transforms/ris3_list.txt
+++ b/transforms/ris3_list.txt
@@ -1,0 +1,3 @@
+ris3_views
+ris3_risk
+he_class_icons

--- a/transforms/ris3_risk.py
+++ b/transforms/ris3_risk.py
@@ -1,0 +1,23 @@
+[{
+    'sheet': 'Risk Map Definitions',
+    'lets': {
+        'iri': 'vm:HE/_{row[Name].as_slug}',
+    },
+    'triples': [
+        ('{iri}', 'rdf:type', 'vm:HE/{row[Class / Category].as_uc}'),
+        ('{iri}', 'vm:name', '{row[Name].as_text}'),
+        ('{iri}', 'vm:description', '{row[Description].as_text}'),
+        ('{iri}', 'owl:sameAs', 'vm:HE/_{row[Map Label Differs?].as_slug}'),
+    ],
+}, {
+    'sheet': 'Risk Map Relationships',
+    'lets': {},
+    'non_unique': ['vm:HE/causes', 'vm:HE/stronglycauses'],
+    'triples': [
+        (
+            'vm:HE/_{row[Subject].as_slug}',
+            'vm:HE/{row[Predicate].as_text}',
+            'vm:HE/_{row[Object].as_slug}',
+        ),
+    ],
+}]


### PR DESCRIPTION
Also list of first pass RIS 3 transforms.

When map label differs, including temporary triple to show common
identity. Relationships are basically just triples already.

Note that the classes are not tied into the ontology at present.

Using convention of underscore for individuals, but no midfix yet.