### PR TITLE
Add requirements.txt for basic install in enviroments that can't handle Poetry

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+openpyxl>=3
+rdflib>=5
+xlrd>=1
+requests>=2.25


### PR DESCRIPTION
Have just spent a while going through `sheet-to-triples` setup for the consultants on a Windows environment and the upshot of it is that Poetry is a no-go there - the things you need to do to get it working are far too technical, and also Windows just sucks for this stuff in general. After trying several different approaches I reverted to the most basic one possible: installing via `pip install -r requirements.txt`, which thankfully still works. 

This is something of a stopgap as we don't want to be updating two sets of requirements files every time, but does the job for now.