### PR TITLE
Make transforms in lists relative to list path, not TRANSFORMS_DIR

### DIFF
--- a/sheet_to_triples/__main__.py
+++ b/sheet_to_triples/__main__.py
@@ -38,9 +38,13 @@ def _parse_book_path(path):
 
 def _parse_transform_list(path):
     transforms = []
+    dir_path = os.path.dirname(path)
     with open(path, 'r') as f:
         for transform in f.read().splitlines():
-            transforms.extend(trans.Transform.iter_from_name(transform))
+            transforms.extend(
+                trans.Transform.iter_from_name(
+                    transform, base_path=dir_path)
+            )
     return transforms
 
 

--- a/sheet_to_triples/trans.py
+++ b/sheet_to_triples/trans.py
@@ -80,9 +80,13 @@ class Transform:
         return f'<{self.__class__.__name__} {self.name!r}>'
 
     @classmethod
-    def iter_from_name(cls, name):
-        transforms_dir = os.getenv('TRANSFORMS_DIR', 'transforms')
-        path = os.path.join(transforms_dir, name + '.py')
+    def iter_from_name(cls, name, base_path=None):
+        if not base_path:
+            base_path = os.getenv('TRANSFORMS_DIR', 'transforms')
+        path = os.path.join(base_path, name)
+        if not path.endswith('.py'):
+            path += '.py'
+
         with open(path, 'r', encoding='utf-8') as f:
             transform = ast.literal_eval(f.read())
             if isinstance(transform, list):


### PR DESCRIPTION
The path derivation behaviour living inside `Transform.iter_from_name` made this slightly hacky, but it's not _too_ bad I think -- just pass it a flag indicating whether you want the old behaviour where the path is derived relative to TRANSFORMS_DIR, or just take the path as-is. Then the list function uses the flag to set paths relative to itself rather than TRANSFORMS_DIR.