### PR TITLE
Add cross_cols for applying logic per row and col

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,9 @@ The top level attributes of a transform are:
 * `skip_empty_rows: bool`
 
   By default the first empty row found in a sheet is treated as the EOF and row parsing will halt if one is encountered. If this flag is set to `True` then empty rows will be skipped over instead and the entire sheet will be parsed.
+* (provisional) `_cross_cols: List[str]`
+
+  If supplied, process triples not only for each row, but for each row/column pair by multiplying the columns given in this value. An extra variable `cell` will be available for interpolation within triples.
 
 
 ## Findings

--- a/sheet_to_triples/field.py
+++ b/sheet_to_triples/field.py
@@ -124,6 +124,24 @@ class Cell:
             return self.as_text
 
 
+class ConditionCell(Cell):
+    """Single value with some extra chaining properties."""
+
+    def __init__(self, colname, value):
+        self._colname = colname
+        self._value = value
+
+    @property
+    def colname(self):
+        return Cell(self._colname)
+
+    @property
+    def truth(self):
+        if self._value:
+            return self
+        raise ValueError('false value')
+
+
 class Row:
     """Group of fields keyed by name."""
 
@@ -135,3 +153,6 @@ class Row:
 
     def __getitem__(self, key):
         return Cell(self.fields[key])
+
+    def condition(self, key):
+        return ConditionCell(key, self.fields[key])

--- a/sheet_to_triples/run.py
+++ b/sheet_to_triples/run.py
@@ -80,7 +80,7 @@ class Runner:
         if self.books and tf.uses_sheet():
             row_iter = xl.iter_sheet(self._get_books(tf.book), tf.sheet)
             return xl.as_rows(
-                row_iter, tf.required_rows(), tf.skip_empty_rows)
+                row_iter, tf.required_cols(), tf.skip_empty_rows)
         return (field.Row(r) for r in getattr(tf, 'data', ()))
 
     @staticmethod

--- a/sheet_to_triples/tests/test_trans.py
+++ b/sheet_to_triples/tests/test_trans.py
@@ -85,24 +85,25 @@ class TransformTestCase(unittest.TestCase):
     def test_uses_sheet_defaults_false(self):
         self.assertFalse(trans.Transform('test', {}).uses_sheet())
 
-    def test_required_rows(self):
+    def test_required_cols(self):
         details = {
             'lets': {
                 'testvar': 'prefix_{row[column_1]}',
                 'nonevar': 'no_row_reference',
             },
+            '_cross_cols': ['column_extra'],
             'triples': [
                 ('{testvar}', 'predicate', '{row[column_2]}')
             ]
         }
         transform = trans.Transform('test', details)
         self.assertEqual(
-            transform.required_rows(),
-            {'column_1', 'column_2'}
+            transform.required_cols(),
+            {'column_1', 'column_2', 'column_extra'}
         )
 
-    def test_required_rows_empty(self):
-        self.assertFalse(trans.Transform('test', {}).required_rows())
+    def test_required_cols_empty(self):
+        self.assertFalse(trans.Transform('test', {}).required_cols())
 
     @unittest.skip
     def test_prepare_queries(self):


### PR DESCRIPTION
For now list of columns in sheet must still be exhaustive, but avoid
repeating triples lines for each column in this case. Also add
conditional that allows for logic on the cell contents but can give
column name as the result value.