### PR TITLE
Fix unittest expected paths when run on Windows.

### DIFF
--- a/sheet_to_triples/tests/test_main.py
+++ b/sheet_to_triples/tests/test_main.py
@@ -132,7 +132,10 @@ class TestParseArgs(unittest.TestCase):
                 _mock_os_path_walk(walk_data):
             args = main.parse_args(argv)
 
-        expected = ['rootdir1/book.xlsx', 'rootdir1/book.xls']
+        expected = [
+            os.path.normpath('rootdir1/book.xlsx'),
+            os.path.normpath('rootdir1/book.xls'),
+        ]
         self.assertEqual([b for b in args.book], expected)
 
         isdir.assert_called_once_with('rootdir1')
@@ -147,8 +150,8 @@ class TestParseArgs(unittest.TestCase):
 
         expected = [
             'transform1.py',
-            'testdir/listtrans.py',
-            'testdir/listtrans2.py',
+            os.path.normpath('testdir/listtrans.py'),
+            os.path.normpath('testdir/listtrans2.py'),
         ]
         self.assertEqual(
             [t.name for t in args.transform],

--- a/sheet_to_triples/tests/test_trans.py
+++ b/sheet_to_triples/tests/test_trans.py
@@ -4,6 +4,7 @@
 """Unittests for the trans.py modules of sheet-to-triples."""
 
 import copy
+import os
 import unittest
 
 from unittest import mock
@@ -39,18 +40,18 @@ class TransformTestCase(unittest.TestCase):
         self.assertIsInstance(transform, trans.Transform)
         self.assertEqual(transform.allow_empty_subject, True)
         mock_open.assert_called_once_with(
-            'test_transforms/test.py', 'r', encoding='utf-8'
+            os.path.normpath('test_transforms/test.py'), 'r', encoding='utf-8'
         )
 
     def test_iter_from_name_with_base_path(self):
         strdetails = '{"allow_empty_subject": True}'
         with _mock_open(strdetails) as mock_open, _mock_env() as mock_env:
             next(trans.Transform.iter_from_name(
-                'test', base_path='/different/path'
+                'test', base_path=os.path.normpath('/different/path')
             ))
 
         mock_open.assert_called_once_with(
-            '/different/path/test.py', 'r', encoding='utf-8'
+            os.path.normpath('/different/path/test.py'), 'r', encoding='utf-8'
         )
         mock_env.assert_not_called()
 


### PR DESCRIPTION
Fixes https://app.productive.io/15481-visual-meaning/projects/130026/tasks/task/1725401?filter=LTE%3D.

Wrapping everything in `os.path.normpath` is a bit of an ugly spelling, but does the job.