### PR TITLE
Save model after adding another graph

### DIFF
--- a/sheet_to_triples/__main__.py
+++ b/sheet_to_triples/__main__.py
@@ -104,8 +104,9 @@ def run_runner(runner, args):
     with debug.context(args.debug):
         if args.non_unique_from:
             runner.use_non_uniques(args.non_unique_from)
-        if args.transform:
-            runner.run(args.transform)
+        if args.add_graph or args.transform:
+            if args.transform:
+                runner.run(args.transform)
             if runner.model:
                 runner.save_model(args.model_out)
         elif runner.verbose:


### PR DESCRIPTION
The fallback behaviour to show the input model now triggers only if
neither --add-graph nor any transform are supplied.