### PR TITLE
Handle namespace bindings more sensibly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,16 @@
 .PHONY: test lint check
 
+DIR = sheet_to_triples/
+
+check: lint test
+
 test:
 	poetry run python -m unittest discover .
 
-lint: 
-	poetry run python -m flake8
+lint:
+	poetry run python -m flake8 $(DIR)
 
-check: test lint
-
-LIB := $(shell find sheet_to_triples/ -name "*.py")
+LIB := $(shell find $(DIR) -name "*.py")
 
 .coverage: $(LIB)
 	poetry run coverage run --source . -m unittest discover .

--- a/sheet_to_triples/tests/test_rdf.py
+++ b/sheet_to_triples/tests/test_rdf.py
@@ -12,30 +12,34 @@ from .. import rdf
 
 class TestRDF(unittest.TestCase):
 
+    @property
+    def resolver(self):
+        return rdf._new_graph().store.namespace
+
     def test_from_qname(self):
-        term = rdf.from_qname('owl:test')
+        term = rdf.from_qname('owl:test', self.resolver)
         self.assertIsInstance(term, rdflib.term.URIRef)
         self.assertEqual(str(term), 'http://www.w3.org/2002/07/owl#test')
 
-    def test_from_qname_prefix_vm(self):
-        term = rdf.from_qname('vm:test')
-        self.assertIsInstance(term, rdflib.term.URIRef)
-        self.assertEqual(str(term), 'http://visual-meaning.com/rdf/test')
-
     def test_from_qname_prefix_http(self):
-        term = rdf.from_qname('http://test.test')
+        term = rdf.from_qname('http://test.test', self.resolver)
         self.assertIsInstance(term, rdflib.term.URIRef)
         self.assertEqual(str(term), 'http://test.test')
+
+    def test_from_qname_unknown_prefix(self):
+        with self.assertRaises(ValueError) as ctx:
+            rdf.from_qname('unk:test', self.resolver)
+        self.assertEqual(str(ctx.exception), 'unknown prefix: unk')
 
     def test_from_identifier_already_ident(self):
         term = rdflib.term.URIRef('test')
         self.assertEqual(
-            rdf.from_identifier(term),
+            rdf.from_identifier(term, None),
             term
         )
 
     def test_from_identifier_sequencepath(self):
-        term = rdf.from_identifier('vm:a / vm:b')
+        term = rdf.from_identifier('vm:a / vm:b', self.resolver)
         expected = [
             'http://visual-meaning.com/rdf/a',
             'http://visual-meaning.com/rdf/b',
@@ -47,13 +51,13 @@ class TestRDF(unittest.TestCase):
         )
 
     def test_from_identifier_prefix_http(self):
-        term = rdf.from_identifier('http://test.test')
+        term = rdf.from_identifier('http://test.test', None)
         self.assertIsInstance(term, rdflib.term.URIRef)
         self.assertEqual(str(term), 'http://test.test')
 
     def test_from_identifier_literal(self):
         self.assertEqual(
-            rdf.from_identifier('test'),
+            rdf.from_identifier('test', None),
             rdflib.Literal('test')
         )
 


### PR DESCRIPTION
General cleanup of identifier and qname parsing, by passing graph
namespace manager logic down to the functions that want to use
resolution of prefixes to namespaces.

Wrap up Formatter class and namespace handling for transforms in
`_Converter` class which adopts the `_as_*()` functions.

Drive by Makefile poke.