### PR TITLE
More useful printing of non-unique triples

### DIFF
--- a/sheet_to_triples/rdf.py
+++ b/sheet_to_triples/rdf.py
@@ -149,7 +149,7 @@ def normalise_model(model, ns, non_uniques, resolve_same, verbose):
             if t[k] in same:
                 t[k] = same[t[k]]
         key = _to_key(t, non_uniques)
-        if verbose and key in by_key:
+        if key in by_key and (verbose or by_key[key]['obj'] != t['obj']):
             print('# dropping {s} {p} {o}'.format(
                 s=_n3(key[0], ns), p=_n3(key[1], ns), o=by_key[key]['obj']))
         by_key[key] = t


### PR DESCRIPTION
If the result would just be duplicated data, only notify when
`--verbose` flag is given, but always notify if the triple is not an
exact match.