### PR TITLE
Tweak rdflib version for dumb windows install

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 openpyxl>=3
-rdflib>=5
+rdflib==5.0.0
 xlrd>=1
 requests>=2.25


### PR DESCRIPTION
As written it installs `rdflib==6.0.0`, which is too new and errors out. Steve and Barbara have both run into issues with this so for now clamp it to `5.0.0`. `poetry install` still seems to work, so leaving that alone for now.

PR for visibility, will self-stamp and merge.