### PR TITLE
Add default empty model if no model argument is passed.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,8 +8,10 @@ description = "Convert tabular data into triples."
 [tool.poetry.dependencies]
 python = "^3.7"
 openpyxl = "^3"
-rdflib = {version = "^5", extras = ["sparql"]}
+rdflib = {version = "5", extras = ["sparql"]}
 xlrd = "^1"
+# pyparsing is sparql dependency? updated to 3.x recently which breaks things
+pyparsing = "^2"
 
 [tool.poetry.dev-dependencies]
 flake8 = "^3.8"

--- a/sheet_to_triples/__main__.py
+++ b/sheet_to_triples/__main__.py
@@ -57,10 +57,11 @@ def parse_args(argv):
         '--add-graph', action='append',
         help='path to existing graph to add to model')
     parser.add_argument(
-        '--model', help='path to json file with existing map model')
+        '--model',
+        help='path to json file with existing map model')
     parser.add_argument(
-        '--model-out', metavar='PATH', default='new.json',
-        help='path to write new jsom file with output map model')
+        '--model-out', metavar='PATH',
+        help='path to write new json file with output map model')
     arg_purge = parser.add_argument(
         '--purge-except', metavar='|'.join(PURGE_MAP.keys()),
         type=PURGE_MAP.get, default='none',
@@ -92,6 +93,8 @@ def parse_args(argv):
             parser.error(f'transforms {need_book} require --book')
     if not args.purge_except:
         parser.error('--purge-except must be one of ' + arg_purge.metavar)
+    if args.model_out and not args.model:
+        args.model = run.default_model
     return args
 
 
@@ -107,7 +110,7 @@ def run_runner(runner, args):
         if args.add_graph or args.transform:
             if args.transform:
                 runner.run(args.transform)
-            if runner.model:
+            if args.model_out:
                 runner.save_model(args.model_out)
         elif runner.verbose:
             run.show_graph(runner.graph)

--- a/sheet_to_triples/run.py
+++ b/sheet_to_triples/run.py
@@ -12,6 +12,8 @@ from . import (
     xl,
 )
 
+default_model = object()
+
 
 class Runner:
     """Encapsulation of new data, existing model, and transform running."""
@@ -34,6 +36,9 @@ class Runner:
             book = {os.path.basename(b): xl.load_book(b) for b in args.book}
         else:
             book = dict()
+        # if args.model == 'default':
+        #     model = {'terms': []}
+        # else:
         model = args.model and cls.load_model(args.model)
         return cls(
             book, model, args.purge_except, args.resolve_same, args.verbose)
@@ -85,6 +90,8 @@ class Runner:
 
     @staticmethod
     def load_model(filepath):
+        if filepath is default_model:
+            return {'terms': []}
         with open(filepath, 'rb') as f:
             return json.load(f)
 

--- a/sheet_to_triples/tests/test_main.py
+++ b/sheet_to_triples/tests/test_main.py
@@ -41,7 +41,7 @@ def _mock_os_path_isdir(isdir):
     return mock.patch('os.path.isdir', return_value=isdir)
 
 
-def _mock_open(data):
+def _mock_open(data=''):
     return mock.patch('builtins.open', mock.mock_open(read_data=data))
 
 
@@ -62,7 +62,7 @@ class TestParseArgs(unittest.TestCase):
             ('book', None),
             ('add_graph', None),
             ('model', None),
-            ('model_out', 'new.json'),
+            ('model_out', None),
             ('resolve_same', True),
             ('debug', False),
             ('verbose', False),
@@ -180,6 +180,11 @@ class TestParseArgs(unittest.TestCase):
 
         mo.assert_called_once_with('listpath.txt', 'r')
 
+    def test_parse_args_model_out_but_no_model(self):
+        argv = ['dummy', 'transform1', '--model-out', 'output.json']
+        args = main.parse_args(argv)
+        self.assertEqual(args.model, run.default_model)
+
     def test_parse_args_bad_purge_except(self):
         argv = ['dummy', 'transform1', '--purge-except', 'bogus']
         buffer = io.StringIO()
@@ -220,12 +225,12 @@ class StubSingleTransform(StubTransform):
 class TestMain(unittest.TestCase):
 
     def test_main_run_transform_save_model(self):
-        argv = ['dummy', 'transform1', '--model', 'test-in.json']
+        argv = ['dummy', 'transform1', '--model-out', 'new.json']
         triples = [('a', 'b', 'c')]
         transform = StubSingleTransform('transform1', triples=triples)
 
         with mock.patch(_iter_from_name, new=transform), \
-                _mock_open('{"terms": []}') as mo:
+                _mock_open() as mo:
             main.main(argv)
 
         # it should run tf.process(), add the triples to the runner model and

--- a/sheet_to_triples/tests/test_run.py
+++ b/sheet_to_triples/tests/test_run.py
@@ -124,6 +124,32 @@ class RunnerTestCase(unittest.TestCase):
 
         self.assertEqual(runner.books, {})
 
+    def test_from_args_default_model(self):
+        argvalues = {
+            'book': [],
+            'model': run.default_model,
+            'purge_except': lambda x: True,
+            'resolve_same': False,
+            'verbose': False,
+        }
+        args = StubArgs(argvalues)
+        runner = run.Runner.from_args(args)
+
+        self.assertEqual(runner.model, {'terms': []})
+
+    def test_from_args_no_model(self):
+        argvalues = {
+            'book': [],
+            'model': None,
+            'purge_except': lambda x: True,
+            'resolve_same': False,
+            'verbose': False,
+        }
+        args = StubArgs(argvalues)
+        runner = run.Runner.from_args(args)
+
+        self.assertEqual(runner.model, None)
+
     def test_init_no_model(self):
         runner = StubRunner().get_runner(args={'model': None})
         self.assertIsInstance(runner.graph, rdflib.graph.Graph)


### PR DESCRIPTION
Because I'm tired of having to pass `--model stub.json` to get it to write output. Now it always has a default empty model if none is passed, but it will only save the model if `--model-out` is passed.

The thinking behind this is that if we're going to have consultants authoring transforms then they're going to need to run this, and so we want to minimise counterintuitive things like having to pass an empty model to write.