### PR TITLE
Add `as_country_code` method on `Field` for two-letter ISO code

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ description = "Convert tabular data into triples."
 
 [tool.poetry.dependencies]
 python = "^3.7"
+pycountry = "^20"
 openpyxl = "^3"
 rdflib = {version = "^5", extras = ["sparql"]}
 xlrd = "^1"

--- a/sheet_to_triples/field.py
+++ b/sheet_to_triples/field.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Visual Meaning Ltd
+# Copyright 2021 Visual Meaning Ltd
 # This is free software licensed as GPL-3.0-or-later - see COPYING for terms.
 
 """Interfaces for mapping from tabular data."""
@@ -7,6 +7,7 @@ import ast
 import json
 import re
 
+import pycountry
 
 _TYPES = {
     'pain': 'vm:Painpoint',
@@ -122,6 +123,10 @@ class Cell:
             return self.as_date
         except AttributeError:
             return self.as_text
+
+    @property
+    def as_country_code(self):
+        return _must(pycountry.countries.get(name=_str(self._value)).alpha_2)
 
 
 class ConditionCell(Cell):

--- a/sheet_to_triples/tests/test_field.py
+++ b/sheet_to_triples/tests/test_field.py
@@ -152,3 +152,20 @@ class CellTestCase(unittest.TestCase):
             field.Cell('7th June').as_date_or_text,
             '7th June'
         )
+
+    def test_as_country_code(self):
+        self.assertEqual(
+            field.Cell('Brazil').as_country_code,
+            'BR'
+        )
+
+    def test_as_country_code_bad_values(self):
+        errors_cases = (
+            (None, ValueError),
+            ('notfound', AttributeError),
+            ('   ', ValueError),
+        )
+        for value, error in errors_cases:
+            with self.subTest(value=value):
+                with self.assertRaises(error):
+                    field.Cell(value).as_country_code


### PR DESCRIPTION
As Martin and Steve are currently engaged in the world's longest argument, I'm taking the opportunity to quickly do tickets. Addresses https://app.productive.io/15481-visual-meaning/projects/130026/tasks/task/1938857?filter=LTE%3D.

Do we want the country code to be lower case?

