### PR TITLE
Update rdflib to version 6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,10 +9,8 @@ description = "Convert tabular data into triples."
 python = "^3.7"
 pycountry = "^20"
 openpyxl = "^3"
-rdflib = {version = "5", extras = ["sparql"]}
+rdflib = {version = "^6.0.2", extras = ["sparql"]}
 xlrd = "^1"
-# pyparsing is sparql dependency? updated to 3.x recently which breaks things
-pyparsing = "^2"
 
 [tool.poetry.dev-dependencies]
 flake8 = "^3.8"

--- a/sheet_to_triples/rdf.py
+++ b/sheet_to_triples/rdf.py
@@ -17,10 +17,6 @@ _USES_MAP_TILES = VM.usesMapTiles
 
 _GEO = (VM.atGeoPoint.toPython(), VM.atGeoPoly.toPython(), VM.name.toPython())
 
-FOAF = rdflib.namespace.FOAF
-# Include test property via hack <http://xmlns.com/foaf/spec/#term_phone>
-FOAF._ClosedNamespace__uris['phone'] = rdflib.URIRef(FOAF.uri + 'phone')
-
 
 def _cast_from_term(t):
     return (

--- a/sheet_to_triples/run.py
+++ b/sheet_to_triples/run.py
@@ -102,4 +102,4 @@ class Runner:
 
 def show_graph(graph):
     """Print graph in human-readable turtle format."""
-    print(graph.serialize(format='turtle').decode('utf-8'))
+    print(graph.serialize(format='turtle'))

--- a/sheet_to_triples/tests/test_rdf.py
+++ b/sheet_to_triples/tests/test_rdf.py
@@ -27,6 +27,12 @@ class TestRDF(unittest.TestCase):
         self.assertIsInstance(term, rdflib.term.URIRef)
         self.assertEqual(str(term), 'http://www.w3.org/2002/07/owl#test')
 
+    def test_from_foaf_phone(self):
+        """Not fully standardised foaf qname still resolves."""
+        term = rdf.from_qname('foaf:phone', self.resolver)
+        self.assertIsInstance(term, rdflib.term.URIRef)
+        self.assertEqual(str(term), 'http://xmlns.com/foaf/0.1/phone')
+
     def test_from_qname_prefix_http(self):
         term = rdf.from_qname('http://test.test', self.resolver)
         self.assertIsInstance(term, rdflib.term.URIRef)


### PR DESCRIPTION
Some small incompatibilities to resolve, but get to remove version
pinning for the pyparsing dependency as well.

The work-around for incomplete FOAF namespace is no longer required,
test added to demonstrate that.