### PR TITLE
Declare minimum Python version to be 3.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Martin Packman <martin.packman@visual-meaning.com>"]
 description = "Convert tabular data into triples."
 
 [tool.poetry.dependencies]
-python = "^3.7"
+python = "^3.8"
 pycountry = "^20"
 openpyxl = "^3"
 rdflib = {version = "^6.0.2", extras = ["sparql"]}

--- a/sheet_to_triples/field.py
+++ b/sheet_to_triples/field.py
@@ -58,7 +58,7 @@ def _literal(value):
     raise ValueError('not a data field')
 
 
-@functools.lru_cache
+@functools.lru_cache(maxsize=None)
 def _resolve_country(name):
     return pycountry.countries.search_fuzzy(name)[0]
 


### PR DESCRIPTION
Using argparse features that require Python 3.8 or later, so update
`pyproject.toml` to reflect that fact.

Also change use of `functools.lru_cache()` to not evict, which in
earlier versions was the preferred spelling anyway.