### PR TITLE
First pass at automatic translation of label data.

### DIFF
--- a/sheet_to_triples/rdf.py
+++ b/sheet_to_triples/rdf.py
@@ -64,6 +64,9 @@ def from_identifier(value, resolver):
         # Fall through for unresolved prefix
     if prefix == 'http':
         return rdflib.URIRef(value)
+    # if ends with language tag, create a Literal with the appropriate lang
+    if re.search(r"@[a-z]{2}$", value):
+        return rdflib.Literal(value, lang=value[-2:])
     return rdflib.Literal(value)
 
 


### PR DESCRIPTION
From a user point of view interacting with this project via the CLI, it does exactly what we want in a nice, low-friction manner. Translating labels which are attached to `vm:Stakeholder`, say, simply requires us to preassemble the data model as step one, as we usually do, and then in step two:

```
python -m sheet_to_triples labels_transform --model model_in.json --model-out model_out.json --translate-labels "vm:Stakeholder" --base-language en
```

And it will automatically try and match Stakeholders it finds in the data model to associated labels, and then use any translated Stakeholder data to translate the labels. 

That is all fine. Unfortunately under the hood this is a _bad_ piece of code (except for the SPARQL, which I'm quite proud of) that relies on too many operations that are 90% similar to what we currently do, but which needed to be crudely duplicated because they didn't go all the way.

Also it needs tests. Also I ran `black` over it which saved me negative time because it reformatted all of the single quotes to double quotes.