### PR TITLE
When updating the model from the graph, exclude blank nodes.

### DIFF
--- a/sheet_to_triples/rdf.py
+++ b/sheet_to_triples/rdf.py
@@ -108,9 +108,14 @@ def graph_from_model(model):
     return g
 
 
+def _maybe_bnode(s, p, o):
+    return isinstance(s, rdflib.term.BNode) or isinstance(o, rdflib.term.BNode)
+
+
 def update_model_terms(model, triples):
     model['terms'].extend(
-        dict(subj=str(s), pred=str(p), obj=str(o)) for s, p, o in triples)
+        dict(subj=str(s), pred=str(p), obj=str(o)) for s, p, o in triples
+        if not _maybe_bnode(s, p, o))
 
 
 def _with_int_maybe(iri):

--- a/sheet_to_triples/tests/test_rdf.py
+++ b/sheet_to_triples/tests/test_rdf.py
@@ -169,6 +169,17 @@ class TestRDF(unittest.TestCase):
         }
         self.assertEqual(model, expected)
 
+    def test_update_model_terms_exclude_bnodes(self):
+        """Filter triples out if EITHER the subj or obj are type BNodes."""
+        model = {'terms': []}
+        bnodes = [
+            (rdflib.term.BNode('subj'), 'pred', 'obj'),
+            ('subj', 'pred', rdflib.term.BNode('obj')),
+        ]
+        rdf.update_model_terms(model, bnodes)
+        expected = {'terms': []}
+        self.assertEqual(model, expected)
+
     def _model_from_triples(self, triples):
         terms = [{'subj': s, 'pred': p, 'obj': o} for s, p, o in triples]
         return {'terms': terms}


### PR DESCRIPTION
Conversion of Blank Nodes from the graph to the model is a one-way operation as we cast them to string, and when the model gets converted back into a graph a string-converted Blank Node will just come out as an `rdflib.Literal`, losing the meaning. 

Further, since the purpose of this module is to convert RDF graphs into JSON that our platform can consume, and the platform has no concept of what a blank node is, this is effectively junk data. So exclude any triples containing blank nodes at the point of converting from the graph to the model.