### PR TITLE
Redo row melting, and add conditional fields and properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,11 @@ The top level attributes of a transform are:
 * `lets: Dict[str, str_template]`
 
   Bind variables which will be set for each row.
+
+* `conds: Dict[str, Tuple(str_template, str_template, str_template)]`
+
+  Variables that are the result of some conditional. The first item in the tuple is the condition, evaluated with `Cell` methods such as `exists`. The second item is the value if True, and the third item is the value if False.
+
 * `query: Dict[str, str_query]`
 
   Bind result of query to be run for each row.
@@ -81,9 +86,9 @@ The top level attributes of a transform are:
 * `skip_empty_rows: bool`
 
   By default the first empty row found in a sheet is treated as the EOF and row parsing will halt if one is encountered. If this flag is set to `True` then empty rows will be skipped over instead and the entire sheet will be parsed.
-* (provisional) `_cross_cols: List[str]`
+* (provisional) `melt_cols: List[str]`
 
-  If supplied, process triples not only for each row, but for each row/column pair by multiplying the columns given in this value. An extra variable `cell` will be available for interpolation within triples.
+  If supplied, process triples not only for each row, but for each row/column pair by multiplying the columns given in this value. Including `melt_cols` will cause an additional column to be added to every row called `_has_melt`, which is a boolean value indicating whether this row contains melted values or not. If `_has_melt` is True, two further columns will be added, `_melt_colname` and `_melt_value`, which contain the column-value pairings for this row for each column in `melt_cols`.
 
 
 ## Findings

--- a/sheet_to_triples/tests/test_field.py
+++ b/sheet_to_triples/tests/test_field.py
@@ -169,3 +169,55 @@ class CellTestCase(unittest.TestCase):
             with self.subTest(value=value):
                 with self.assertRaises(error):
                     field.Cell(value).as_country_code
+
+    def test_exists_true(self):
+        self.assertTrue(field.Cell('exists').exists)
+
+    def test_exists_false(self):
+        self.assertFalse(field.Cell(None).exists)
+
+    def test_not_exists_true(self):
+        self.assertTrue(field.Cell(None).not_exists)
+
+    def test_not_exists_false(self):
+        self.assertFalse(field.Cell('exists').not_exists)
+
+
+class RowTestCase(unittest.TestCase):
+
+    def test_cols_disjoint_true(self):
+        row = field.Row({'col1': 'a', 'col2': 'b'})
+        self.assertTrue(row.cols_disjoint(['col3', 'col4']))
+
+    def test_cols_disjoint_false(self):
+        row = field.Row({'col1': 'a', 'col2': 'b'})
+        self.assertFalse(row.cols_disjoint(['col2', 'col3']))
+
+    def test_melt(self):
+        self.maxDiff = None
+        row = field.Row({'col1': 'a', 'col2': 'b', 'col3': 'c'})
+
+        expected = [
+            {
+                'col1': 'a', 'col2': 'b', 'col3': 'c',
+                '_melt_colname': 'col2', '_melt_value': 'b', '_has_melt': True
+            },
+            {
+                'col1': 'a', 'col2': 'b', 'col3': 'c',
+                '_melt_colname': 'col3', '_melt_value': 'c', '_has_melt': True
+            },
+        ]
+        self.assertEqual(
+            [r for r in row.melt(['col2', 'col3'])],
+            [field.Row(r) for r in expected]
+        )
+
+    def test_has_melt_false_if_no_melt_cols(self):
+        row = field.Row({'col1': 'a', 'col2': 'b', 'col3': 'c'})
+        expected = [
+            {'col1': 'a', 'col2': 'b', 'col3': 'c', '_has_melt': False}
+        ]
+        self.assertEqual(
+            [r for r in row.melt(['col4'])],
+            [field.Row(r) for r in expected]
+        )


### PR DESCRIPTION
Required change for https://app.productive.io/15481-visual-meaning/projects/130026/tasks/task/2323091?filter=MTEyNDM2.

- Add `conds` field to transform properties. This is a tuple containing three objects:
    - A conditional evaluating to True or False, using `field.Cell` properties.
    - Value if True
    - Value if False
- Remove `field.ConditionCell` and replace with `exists` and `not_exists` properties on `field.Cell`.
- Redo `_cross_cols` into `melt_cols`, with associated behaviour changes in `transform.Transform.process` and `field.Row`.
- Many additional inbuilt methods for `field.Row` - `__contains__, `__setitem__`, `__eq__`.
 
I haven't updated the Readme yet as I'm leaving that for after the code changes are approved.
