### PR TITLE
Some quick fixes for bugs in the `row.melt` code.

### DIFF
--- a/sheet_to_triples/field.py
+++ b/sheet_to_triples/field.py
@@ -164,14 +164,19 @@ class Row:
     def __eq__(self, other):
         return self.fields == other.fields
 
+    def col_exists(self, col):
+        # check if a column exists with a value that isn't None
+        return self.fields.get(col) is not None
+
     def cols_disjoint(self, cols):
-        return self.fields.keys().isdisjoint(cols)
+        exists_cols = {k for k, v in self.fields.items() if v is not None}
+        return exists_cols.isdisjoint(cols)
 
     def melt(self, melt_cols):
         self.fields['_has_melt'] = not self.cols_disjoint(melt_cols)
         for col in melt_cols:
             melted_row = Row(dict(self.fields))
-            if col in melted_row and melted_row[col].exists:
+            if melted_row.col_exists(col):
                 melted_row['_melt_colname'] = col
                 melted_row['_melt_value'] = str(melted_row[col])
             yield melted_row

--- a/sheet_to_triples/tests/test_field.py
+++ b/sheet_to_triples/tests/test_field.py
@@ -186,7 +186,7 @@ class CellTestCase(unittest.TestCase):
 class RowTestCase(unittest.TestCase):
 
     def test_cols_disjoint_true(self):
-        row = field.Row({'col1': 'a', 'col2': 'b'})
+        row = field.Row({'col1': 'a', 'col2': 'b', 'col3': None})
         self.assertTrue(row.cols_disjoint(['col3', 'col4']))
 
     def test_cols_disjoint_false(self):

--- a/sheet_to_triples/tests/test_trans.py
+++ b/sheet_to_triples/tests/test_trans.py
@@ -280,7 +280,7 @@ class TransformTestCase(unittest.TestCase):
         details = {
             'data': [
                 {'col1': 'http://a.test', 'col2': '1'},
-                {'col1': 'http://b.test'}
+                {'col1': 'http://b.test', 'col2': None},
             ],
             'lets': {
                 'iri': '{row[col1]}/iri'

--- a/sheet_to_triples/trans.py
+++ b/sheet_to_triples/trans.py
@@ -171,7 +171,7 @@ class Transform:
             cond, true, false = (
                 converter.as_obj(n, params) for n in self.conds[c]
             )
-            params[c] = str(true) if cond else str(false)
+            params[c] = str(true) if str(cond) == "True" else str(false)
 
         for k, q in query_map.items():
             result = list(q(initBindings=params))


### PR DESCRIPTION
Two bugs:

- Resolving a condition in a transform will produce an `rdf.Literal("True")` or `rdf.Literal("False")` value. This will always evaluate to True, so it needs to be cast to string and then checked against the literal string value `"True"`. It's a bit of a nasty solution but works as a stopgap to get this code working.
- Rows parsed from Excel workbooks with empty columns still have `{'colname': None}` entries in the `fields` dict, so checking for the existence of the  column name is not enough when we're interested in _populated_ columns. Check for both column presence and then a column value in the `disjoint` operation.

