### PR TITLE
Add `as_rag_category` and `must_exist` fields.

### DIFF
--- a/sheet_to_triples/field.py
+++ b/sheet_to_triples/field.py
@@ -31,6 +31,12 @@ _CAPEFFECTS = {
     'vm:Brightspot': 'vm:aidsCapitalType',
 }
 
+_RAGCATEGORIES = {
+    'Red': 'vm:_judged-negative',
+    'Amber': 'vm:_judged-neutral',
+    'Green': 'vm:_judged-positive',
+}
+
 
 def _must(value, exception_type=ValueError):
     """Raise exception_type if value is falsey."""
@@ -104,6 +110,10 @@ class Cell:
         return _must(_CAPEFFECTS.get(self.as_type))
 
     @property
+    def as_rag_category(self):
+        return _must(_RAGCATEGORIES.get(self._value))
+
+    @property
     def as_type(self):
         return _must(_TYPES.get(_str(self._value)[:4].lower()), TypeError)
 
@@ -133,6 +143,11 @@ class Cell:
     @property
     def as_country_code(self):
         return _resolve_country(_str(self._value)).alpha_2.lower()
+
+    @property
+    def must_exist(self):
+        if _must(self._value):
+            return ''
 
     @property
     def exists(self):

--- a/sheet_to_triples/tests/test_field.py
+++ b/sheet_to_triples/tests/test_field.py
@@ -89,6 +89,23 @@ class CellTestCase(unittest.TestCase):
                 with self.assertRaises(error):
                     field.Cell(value).as_capital_effect
 
+    def test_as_rag_category(self):
+        self.assertEqual(
+            field.Cell('Amber').as_rag_category,
+            'vm:_judged-neutral'
+        )
+
+    def test_as_rag_category_bad_values(self):
+        errors_cases = (
+            (None, ValueError),
+            ('notfound', ValueError),
+            ('   ', ValueError),
+        )
+        for value, error in errors_cases:
+            with self.subTest(value=value):
+                with self.assertRaises(error):
+                    field.Cell(value).as_rag_category
+
     def test_as_type(self):
         self.assertEqual(
             field.Cell('   Painpoint   ').as_type,
@@ -181,6 +198,13 @@ class CellTestCase(unittest.TestCase):
 
     def test_not_exists_false(self):
         self.assertFalse(field.Cell('exists').not_exists)
+
+    def test_must_exist_true(self):
+        self.assertEqual(field.Cell('exists').must_exist, '')
+
+    def test_must_exist_false(self):
+        with self.assertRaises(ValueError):
+            field.Cell('').must_exist
 
 
 class RowTestCase(unittest.TestCase):


### PR DESCRIPTION
These changes were required to ingest the LECM data. `must_exist` is useful for including/omitting rows based on a cell being populated or not.