### PR TITLE
Speculative changes to handle merged cells and multiple tabs

### DIFF
--- a/sheet_to_triples/run.py
+++ b/sheet_to_triples/run.py
@@ -3,6 +3,7 @@
 
 """Run group of transforms on existing data and graph."""
 
+import itertools
 import json
 import os
 
@@ -83,7 +84,14 @@ class Runner:
 
     def _iter_data(self, tf):
         if self.books and tf.uses_sheet():
-            row_iter = xl.iter_sheet(self._get_books(tf.book), tf.sheet)
+            if isinstance(tf.sheet, list):
+                row_iter = itertools.chain(
+                    *[xl.iter_sheet(
+                        self._get_books(tf.book), sheet
+                    ) for sheet in tf.sheet]
+                )
+            else:
+                row_iter = xl.iter_sheet(self._get_books(tf.book), tf.sheet)
             return xl.as_rows(
                 row_iter, tf.required_cols(), tf.skip_empty_rows)
         return (field.Row(r) for r in getattr(tf, 'data', ()))

--- a/sheet_to_triples/tests/test_xl.py
+++ b/sheet_to_triples/tests/test_xl.py
@@ -14,6 +14,7 @@ class StubSheet:
 
     def __init__(self, name):
         self.name = name
+        self.merged_cells = None
 
     def _get_rows(self, caller):
         return 'test {} {}'.format(caller, self.name)

--- a/sheet_to_triples/xlsx.py
+++ b/sheet_to_triples/xlsx.py
@@ -24,4 +24,14 @@ class Book:
             return cls(openpyxl.load_workbook(path, data_only=True))
 
     def iter_rows_in_sheet(self, sheet):
-        return self._book[sheet].iter_rows()
+        sheet = self._book[sheet]
+        while sheet.merged_cells:
+            for merged in sheet.merged_cells:
+                mc_value = str(merged.start_cell.value).strip()
+                sheet.unmerge_cells(str(merged))
+                for merged_cell in merged.cells:
+                    sheet.cell(
+                        row=merged_cell[0],
+                        column=merged_cell[1],
+                    ).value = mc_value
+        return sheet.iter_rows()


### PR DESCRIPTION
- Iterate through multiple sheets of data in the same workbook and run the same transform on each one.
- Un-merge merged cells, populating all resulting cells with the value from the merged cell.

I don't think it's a good idea to merge this one in, and not just because I'm extremely lazy and don't want to write tests for it. The unmerge cell code looked like it was working but encountered edge cases that forced a switch to Rosi's consolidated data sheet, and I don't think either of these features are a great idea in general because they intended to specifically enable un-clean data practices in Excel workbooks.  It's much easier to say no if our software literally can't ingest them.