### PR TITLE
Run transforms from list before transforms from arguments

### DIFF
--- a/sheet_to_triples/__main__.py
+++ b/sheet_to_triples/__main__.py
@@ -100,8 +100,8 @@ def parse_args(argv):
             parser, trans.Transform.iter_from_name(name), name
         ) for name in args.transform
     ))
-    args.transform.extend(list_from_parser_iter(
-        parser, _transform_list(args._from_list), '--from-list'))
+    args.transform[:0] = list_from_parser_iter(
+        parser, _transform_list(args._from_list), '--from-list')
     args.non_unique_from = list_from_parser_iter(
         parser, _transform_list(args._non_unique_from), '--non-unique-from')
 

--- a/sheet_to_triples/tests/test_main.py
+++ b/sheet_to_triples/tests/test_main.py
@@ -143,9 +143,9 @@ class TestParseArgs(fake_filesystem_unittest.TestCase):
         args = main.parse_args(argv)
 
         expected = [
-            'transform1.py',
             os.path.normpath('testdir/listtrans.py'),
             os.path.normpath('testdir/listtrans2.py'),
+            'transform1.py',
         ]
         self.assertEqual(
             [t.name for t in args.transform],


### PR DESCRIPTION
Currently `--fromt-list` transforms are run after transforms passed specifically as arguments. This means that if the `from-list` transforms are adding the same terms as the argument transforms, the `from-list` terms will win out in the deuping stage as they are added last.  This is (probably) undesirable behaviour, as if a user is going to the trouble of passing transforms-as-arguments they're probably of higher importance than the ones from the list. So, always run `--from-list` transforms _before_ everything else.