### PR TITLE
Default non_uniques and ability to pass in non_uniques to Runner

### DIFF
--- a/sheet_to_triples/run.py
+++ b/sheet_to_triples/run.py
@@ -14,11 +14,22 @@ from . import (
 
 default_model = object()
 
+# TODO: this should not hardcode RDF namespaces
+_default_non_unique = {'http://visual-meaning.com/rdf/classOfInterest'}
+
 
 class Runner:
     """Encapsulation of new data, existing model, and transform running."""
 
-    def __init__(self, books, model, purge_except, resolve_same, verbose):
+    def __init__(
+        self,
+        books,
+        model,
+        purge_except,
+        resolve_same,
+        verbose,
+        non_unique=None
+    ):
         self.books = books
         self.model = model
         if model:
@@ -26,7 +37,9 @@ class Runner:
             self.graph = rdf.graph_from_model(model)
         else:
             self.graph = rdf.graph_from_triples(())
-        self.non_unique = set()
+        self.non_unique = non_unique
+        if self.non_unique is None:
+            self.non_unique = _default_non_unique
         self.resolve_same = resolve_same
         self.verbose = verbose
 

--- a/sheet_to_triples/tests/test_main.py
+++ b/sheet_to_triples/tests/test_main.py
@@ -286,5 +286,4 @@ class TestMain(fake_filesystem_unittest.TestCase):
 
         runner = run.Runner.from_args(args)
         main.run_runner(runner, args)
-
-        self.assertEqual(runner.non_unique, non_uniques)
+        self.assertEqual(runner.non_unique, non_uniques.union(run._default_non_unique))

--- a/sheet_to_triples/tests/test_run.py
+++ b/sheet_to_triples/tests/test_run.py
@@ -63,6 +63,7 @@ class StubRunner:
             'purge_except': lambda x: True,
             'resolve_same': False,
             'verbose': False,
+            'non_unique': set(),
         }
 
     def get_runner(self, args={}):
@@ -97,9 +98,9 @@ class RunnerTestCase(unittest.TestCase):
         expected_attrs = [
             ('books', expected_books),
             ('model', model),
-            ('non_unique', set()),
             ('resolve_same', False),
-            ('verbose', False)
+            ('verbose', False),
+            ('non_unique', run._default_non_unique),
         ]
         for attr, expected in expected_attrs:
             with self.subTest(attr=attr):
@@ -231,9 +232,10 @@ class RunnerTestCase(unittest.TestCase):
             'non_unique': ['http://pred']
         }
         transform = trans.Transform('test', details)
-        runner = StubRunner().get_runner()
+        # initialise with non-empty default non_unique list
+        runner = StubRunner().get_runner({'non_unique': {'http://a.test'}})
         runner.run([transform])
-        self.assertEqual(runner.non_unique, {'http://pred'})
+        self.assertEqual(runner.non_unique, {'http://a.test', 'http://pred'})
 
     def _create_row_iter(self, rows):
         row_iter = []


### PR DESCRIPTION
Slightly odd thing where you have to pass in a `set()` to most of the tests in order to override the default, but not too painful in the end.

`ClassOfInterest` I'm still not happy with, but I don't think we're going to come up with a better term that everyone agrees with. It at least partially sums up what we're trying to capture here.

One concern I just thought of is that this is is a public repo and it's the first time we've coded actual business logic into this - this may not be the right approach.