### PR TITLE
Tidy up some as_slug edge cases

### DIFF
--- a/sheet_to_triples/field.py
+++ b/sheet_to_triples/field.py
@@ -85,8 +85,8 @@ class Cell:
 
     @property
     def as_slug(self):
-        content = _str(self._value).replace('&', 'and')
-        return _must(self._pattern.sub('-', content).lower())
+        content = _str(self._value).replace('&', ' and ')
+        return _must(self._pattern.sub('-', content).strip('-').lower())
 
     @property
     def as_uc(self):

--- a/sheet_to_triples/tests/test_field.py
+++ b/sheet_to_triples/tests/test_field.py
@@ -29,6 +29,20 @@ class CellTestCase(unittest.TestCase):
         with self.assertRaises(ValueError):
             field.Cell('    ').as_slug
 
+    def test_as_slug_oddities(self):
+        cases = [
+            ('Oliver!', 'oliver'),
+            ("'nduja", 'nduja'),
+            ('C&P', 'c-and-p'),
+            ('Update State of Railway (e.g. lock route etc.)',
+             'update-state-of-railway-e-g-lock-route-etc'),
+            ('Shan\ufffd', 'shan'),
+            ('Siân', 'siân'),
+        ]
+        for value, expected in cases:
+            with self.subTest(value=value):
+                self.assertEqual(field.Cell(value).as_slug, expected)
+
     def test_as_uc(self):
         self.assertEqual(
             field.Cell('   Some?letters+<and>characters   ').as_uc,


### PR DESCRIPTION
Tweak sluggification logic to make slightly nicer slugs. Strip leading
and trailing non-word character replacements, and force 'and' spacing.

Add some more tests showing expected transformations.