### PR TITLE
Add argument sheet-encoding for decoding csv files

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ rdflib==6.2.0
 xlrd>=1
 requests>=2.25
 pycountry
+pyfakefs

--- a/sheet_to_triples/__main__.py
+++ b/sheet_to_triples/__main__.py
@@ -84,9 +84,6 @@ def parse_args(argv):
     parser.add_argument(
         '-v', '--verbose', action='store_true', help='show details as turtle')
     parser.add_argument(
-        '--sheet-encoding', default='utf-8',
-        help='encoding method for csv file')
-    parser.add_argument(
         '--from-list', dest='_from_list',
         help='add multiple transforms from a text file of transform names')
     parser.add_argument(

--- a/sheet_to_triples/__main__.py
+++ b/sheet_to_triples/__main__.py
@@ -84,6 +84,9 @@ def parse_args(argv):
     parser.add_argument(
         '-v', '--verbose', action='store_true', help='show details as turtle')
     parser.add_argument(
+        '--sheet-encoding', default='utf-8',
+        help='encoding method for csv file')
+    parser.add_argument(
         '--from-list', dest='_from_list',
         help='add multiple transforms from a text file of transform names')
     parser.add_argument(

--- a/sheet_to_triples/read_csv.py
+++ b/sheet_to_triples/read_csv.py
@@ -26,8 +26,8 @@ class Book:
     def from_path(cls, path):
         return cls(path)
 
-    def iter_rows_in_sheet(self, sheet):
-        with open(self._path, 'r') as csv_file:
+    def iter_rows_in_sheet(self, sheet, sheet_encoding):
+        with open(self._path, 'r', encoding=sheet_encoding) as csv_file:
             try:
                 for index, row in enumerate(csv.reader(csv_file)):
                     yield [Cell(v) for v in row]

--- a/sheet_to_triples/run.py
+++ b/sheet_to_triples/run.py
@@ -32,10 +32,12 @@ class Runner:
         purge_except,
         resolve_same,
         verbose,
+        sheet_encoding='utf-8',
         non_unique=None
     ):
         self.books = books
         self.model = model
+        self.sheet_encoding = sheet_encoding
         if model:
             rdf.purge_terms(model, purge_except, verbose)
             self.graph = rdf.graph_from_model(model)
@@ -58,7 +60,8 @@ class Runner:
         # else:
         model = args.model and cls.load_model(args.model)
         return cls(
-            book, model, args.purge_except, args.resolve_same, args.verbose)
+            book, model, args.purge_except, args.resolve_same, args.verbose,
+            args.sheet_encoding)
 
     def use_non_uniques(self, old_transforms):
         for tf in old_transforms:
@@ -100,7 +103,8 @@ class Runner:
 
     def _iter_data(self, tf):
         if self.books and tf.uses_sheet():
-            row_iter = xl.iter_sheet(self._get_books(tf.book), tf.sheet)
+            row_iter = xl.iter_sheet(
+                self._get_books(tf.book), tf.sheet, self.sheet_encoding)
             return xl.as_rows(
                 row_iter, tf.required_cols(), tf.skip_empty_rows)
         return (field.Row(r) for r in getattr(tf, 'data', ()))

--- a/sheet_to_triples/run.py
+++ b/sheet_to_triples/run.py
@@ -32,12 +32,10 @@ class Runner:
         purge_except,
         resolve_same,
         verbose,
-        sheet_encoding='utf-8',
         non_unique=None
     ):
         self.books = books
         self.model = model
-        self.sheet_encoding = sheet_encoding
         if model:
             rdf.purge_terms(model, purge_except, verbose)
             self.graph = rdf.graph_from_model(model)
@@ -60,8 +58,7 @@ class Runner:
         # else:
         model = args.model and cls.load_model(args.model)
         return cls(
-            book, model, args.purge_except, args.resolve_same, args.verbose,
-            args.sheet_encoding)
+            book, model, args.purge_except, args.resolve_same, args.verbose)
 
     def use_non_uniques(self, old_transforms):
         for tf in old_transforms:
@@ -104,7 +101,7 @@ class Runner:
     def _iter_data(self, tf):
         if self.books and tf.uses_sheet():
             row_iter = xl.iter_sheet(
-                self._get_books(tf.book), tf.sheet, self.sheet_encoding)
+                self._get_books(tf.book), tf.sheet, tf.sheet_encoding)
             return xl.as_rows(
                 row_iter, tf.required_cols(), tf.skip_empty_rows)
         return (field.Row(r) for r in getattr(tf, 'data', ()))

--- a/sheet_to_triples/tests/test_run.py
+++ b/sheet_to_triples/tests/test_run.py
@@ -84,6 +84,7 @@ class RunnerTestCase(unittest.TestCase):
             'purge_except': lambda x: True,
             'resolve_same': False,
             'verbose': False,
+            'sheet_encoding': 'utf-8',
         }
         args = StubArgs(argvalues)
         model_data = json.dumps(model)
@@ -117,6 +118,7 @@ class RunnerTestCase(unittest.TestCase):
             'purge_except': lambda x: True,
             'resolve_same': False,
             'verbose': False,
+            'sheet_encoding': 'utf-8',
         }
         args = StubArgs(argvalues)
         model_data = json.dumps({'terms': []})
@@ -132,6 +134,7 @@ class RunnerTestCase(unittest.TestCase):
             'purge_except': lambda x: True,
             'resolve_same': False,
             'verbose': False,
+            'sheet_encoding': 'utf-8',
         }
         args = StubArgs(argvalues)
         runner = run.Runner.from_args(args)
@@ -145,6 +148,7 @@ class RunnerTestCase(unittest.TestCase):
             'purge_except': lambda x: True,
             'resolve_same': False,
             'verbose': False,
+            'sheet_encoding': 'utf-8',
         }
         args = StubArgs(argvalues)
         runner = run.Runner.from_args(args)
@@ -287,7 +291,8 @@ class RunnerTestCase(unittest.TestCase):
             },
         ]
         self.assertEqual(runner.model, {'terms': expected_terms})
-        mis.assert_called_once_with(['book object'], 'test_sheet.xlsx')
+        mis.assert_called_once_with(
+            ['book object'], 'test_sheet.xlsx', 'utf-8')
 
     def test_run_with_sheet_but_no_book(self):
         details = {

--- a/sheet_to_triples/tests/test_run.py
+++ b/sheet_to_triples/tests/test_run.py
@@ -84,7 +84,6 @@ class RunnerTestCase(unittest.TestCase):
             'purge_except': lambda x: True,
             'resolve_same': False,
             'verbose': False,
-            'sheet_encoding': 'utf-8',
         }
         args = StubArgs(argvalues)
         model_data = json.dumps(model)
@@ -118,7 +117,6 @@ class RunnerTestCase(unittest.TestCase):
             'purge_except': lambda x: True,
             'resolve_same': False,
             'verbose': False,
-            'sheet_encoding': 'utf-8',
         }
         args = StubArgs(argvalues)
         model_data = json.dumps({'terms': []})
@@ -134,7 +132,6 @@ class RunnerTestCase(unittest.TestCase):
             'purge_except': lambda x: True,
             'resolve_same': False,
             'verbose': False,
-            'sheet_encoding': 'utf-8',
         }
         args = StubArgs(argvalues)
         runner = run.Runner.from_args(args)
@@ -148,7 +145,6 @@ class RunnerTestCase(unittest.TestCase):
             'purge_except': lambda x: True,
             'resolve_same': False,
             'verbose': False,
-            'sheet_encoding': 'utf-8',
         }
         args = StubArgs(argvalues)
         runner = run.Runner.from_args(args)

--- a/sheet_to_triples/trans.py
+++ b/sheet_to_triples/trans.py
@@ -76,6 +76,7 @@ class Transform:
         'allow_empty_subject',
         'skip_empty_rows',
         'melt_cols',
+        'sheet_encoding',
     )
 
     def __init__(self, name, details):
@@ -86,6 +87,7 @@ class Transform:
         self.conds = dict()
         self.triples = []
         self.melt_cols = ()
+        self.sheet_encoding = 'utf-8'
         for k in details:
             setattr(self, k, details[k])
 

--- a/sheet_to_triples/xl.py
+++ b/sheet_to_triples/xl.py
@@ -21,11 +21,11 @@ def load_book(filepath):
     return Book.from_path(filepath)
 
 
-def iter_sheet(books, sheet_name):
+def iter_sheet(books, sheet_name, sheet_encoding='utf-8'):
     last_err = None
     for book in books:
         try:
-            return book.iter_rows_in_sheet(sheet_name)
+            return book.iter_rows_in_sheet(sheet_name, sheet_encoding)
         except KeyError as e:
             last_err = e
     raise ValueError(f'sheet {sheet_name!r} not found') from last_err

--- a/sheet_to_triples/xls.py
+++ b/sheet_to_triples/xls.py
@@ -19,7 +19,7 @@ class Book:
     def from_path(cls, path):
         return cls(xlrd.open_workbook(path))
 
-    def iter_rows_in_sheet(self, sheet):
+    def iter_rows_in_sheet(self, sheet, *args):
         if sheet not in self._book.sheet_names():
             raise KeyError(sheet)
         return self._book.sheet_by_name(sheet).get_rows()

--- a/sheet_to_triples/xlsx.py
+++ b/sheet_to_triples/xlsx.py
@@ -29,7 +29,7 @@ class Book:
             warnings.filterwarnings('ignore', '.*extension is not supported')
             return cls(openpyxl.load_workbook(path, data_only=True))
 
-    def iter_rows_in_sheet(self, sheet):
+    def iter_rows_in_sheet(self, sheet, *args):
         return (
             tuple(_clean(cell) for cell in row)
             for row in self._book[sheet].iter_rows()


### PR DESCRIPTION
This only applies to csv files and does nothing to excel files. The default decoding for csv files is `utf-8`, `sheet-encoding` allows providing other decoding options like `cp1252`. 