### PR TITLE
Support loading terms only as model

### DIFF
--- a/sheet_to_triples/run.py
+++ b/sheet_to_triples/run.py
@@ -53,9 +53,6 @@ class Runner:
             book = {os.path.basename(b): xl.load_book(b) for b in args.book}
         else:
             book = dict()
-        # if args.model == 'default':
-        #     model = {'terms': []}
-        # else:
         model = args.model and cls.load_model(args.model)
         return cls(
             book, model, args.purge_except, args.resolve_same, args.verbose)
@@ -111,7 +108,12 @@ class Runner:
         if filepath is default_model:
             return {'terms': []}
         with open(filepath, 'rb') as f:
-            return json.load(f)
+            model = json.load(f)
+        if isinstance(model, dict) and 'terms' in model:
+            return model
+        if isinstance(model, list) and all(isinstance(t, dict) for t in model):
+            return {'terms': model}
+        raise ValueError('invalid model: ' + filepath)
 
     def save_model(self, filepath):
         with open(filepath, 'w') as f:

--- a/sheet_to_triples/tests/test_run.py
+++ b/sheet_to_triples/tests/test_run.py
@@ -383,11 +383,26 @@ class RunnerTestCase(unittest.TestCase):
         runner = StubRunner().get_runner()
         self.assertIsInstance(runner.ns, rdflib.namespace.NamespaceManager)
 
-    def test_load_model(self):
-        with _mock_open('["some", "json"]') as mo:
+    def test_load_model_full(self):
+        with _mock_open('{"terms": []}') as mo:
             data = run.Runner.load_model('test.json')
 
-        self.assertEqual(data, ['some', 'json'])
+        self.assertEqual(data, {'terms': []})
+        mo.assert_called_once_with('test.json', 'rb')
+
+    def test_load_model_terms(self):
+        terms = [{'subj': 'a-subj', 'pred': 'a-pred', 'obj': 'a-obj'}]
+        with _mock_open(json.dumps(terms)) as mo:
+            data = run.Runner.load_model('test.json')
+
+        self.assertEqual(data, {'terms': terms})
+        mo.assert_called_once_with('test.json', 'rb')
+
+    def test_load_model_invalid(self):
+        with _mock_open('["some", "json"]') as mo:
+            with self.assertRaises(ValueError):
+                run.Runner.load_model('test.json')
+
         mo.assert_called_once_with('test.json', 'rb')
 
     def test_save_model(self):


### PR DESCRIPTION
Just wrap in a containing dict in that case on loading.

Also do a bit more validation and raise an error if the model looks unlikely.