### PR TITLE
Switch to ruff for lint checking and more make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,13 @@
-.PHONY: test lint check
+.PHONY: test lint fix check coverage install all
 
 DIR = sheet_to_triples/
+
+all: install check
+
+poetry.lock: pyproject.toml
+	poetry install && touch poetry.lock
+
+install: poetry.lock
 
 check: lint test
 
@@ -8,7 +15,10 @@ test:
 	poetry run python -m unittest discover .
 
 lint:
-	poetry run python -m flake8 $(DIR)
+	poetry run python -m ruff $(DIR)
+
+fix:
+	poetry run python -m ruff $(DIR) --fix
 
 LIB := $(shell find $(DIR) -name "*.py")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,9 @@ rdflib = {version = "^6.0.2", extras = ["sparql"]}
 xlrd = "^1"
 
 [tool.poetry.dev-dependencies]
-flake8 = "^3.8"
+ruff = "^0.0.253"
 coverage = "^5.5"
 pyfakefs = "^4.5"
+
+[tool.ruff]
+select = ["C9", "E", "F", "W"]


### PR DESCRIPTION
Lint using ruff which is fast and can fix some issues, though is currently still missing a few pycodestyle rules.

Add `make fix` command for easier lint addressing.

Add `make install` for dependencies with poetry and `make all`.