### PR TITLE
Update installation for Poetry

### DIFF
--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -21,7 +21,6 @@ jobs:
       - name: install
         run: |
           pip3 install poetry
-          poetry config experimental.new-installer false
           poetry install --no-root
       - name: test
         run: |


### PR DESCRIPTION
This setting was deprecated in Poetry 1.5.0 https://python-poetry.org/blog/announcing-poetry-1.5.0/, which is what the gating thingy is now installing.