### PR TITLE
Version bump rdflib + python

### DIFF
--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: "3.8"
+          python-version: "3.11"
       - name: install
         run: |
           pip3 install poetry

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,10 +6,10 @@ authors = ["Martin Packman <martin.packman@visual-meaning.com>"]
 description = "Convert tabular data into triples."
 
 [tool.poetry.dependencies]
-python = "^3.8"
+python = "^3.11"
 pycountry = "^20"
 openpyxl = "^3"
-rdflib = {version = "^6.0.2", extras = ["sparql"]}
+rdflib = {version = "^7.0.0", extras = ["sparql"]}
 xlrd = "^1"
 
 [tool.poetry.dev-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 openpyxl>=3
-rdflib==6.2.0
+rdflib==7.0.0
 xlrd>=1
 requests>=2.25
 pycountry


### PR DESCRIPTION
`rdflib 7.0.0` is the newest package version, which also requires python>=3.8. Updating both rdflib + python.