### PR TITLE
Removed illegal characters.

### DIFF
--- a/sheet_to_triples/tests/test_xl.py
+++ b/sheet_to_triples/tests/test_xl.py
@@ -212,3 +212,14 @@ class TestXlsx(unittest.TestCase):
             list(test_book.iter_rows_in_sheet('sheet'))[0]
         ]
         self.assertEqual(output, ['a\r', 'b\r', None])
+
+    def test_removed_illegal_characters(self):
+        test_data = [
+            ('a_x0004_', 'b_x000C_'),
+        ]
+        test_book = xlsx.Book({'sheet': StubXlsxSheet(test_data)})
+        output = [
+            cell.value for cell in
+            list(test_book.iter_rows_in_sheet('sheet'))[0]
+        ]
+        self.assertEqual(output, ['a', 'b'])

--- a/sheet_to_triples/xlsx.py
+++ b/sheet_to_triples/xlsx.py
@@ -6,11 +6,17 @@
 import warnings
 
 import openpyxl
+from openpyxl.cell.cell import ILLEGAL_CHARACTERS_RE
+
+
+def _remove_illegal(value):
+    return ILLEGAL_CHARACTERS_RE.sub(r'', value)
 
 
 def _clean(cell):
     if isinstance(cell.value, str):
-        cell.value = openpyxl.utils.escape.unescape(cell.value)
+        unescaped = openpyxl.utils.escape.unescape(cell.value)
+        cell.value = _remove_illegal(unescaped)
     return cell
 
 


### PR DESCRIPTION
The unescape method parses every `_x----_` substring into ASCIII but amongst those, [some are not allowed](https://foss.heptapod.net/openpyxl/openpyxl/-/blob/branch/3.1/openpyxl/cell/cell.py#L164) in the setter.

