### PR TITLE
Improved conditional handling

### DIFF
--- a/sheet_to_triples/field.py
+++ b/sheet_to_triples/field.py
@@ -96,12 +96,7 @@ class Cell:
 
     @property
     def as_uc(self):
-        return _must(
-            ''.join(
-                [x.title() if x.islower()
-                 else x for x in re.findall(r'\w+', self._value)]
-            )
-        )
+        return _must(self._pattern.sub('', _str(self._value).title()))
 
     @property
     def as_lc(self):
@@ -190,8 +185,8 @@ class Cell:
     def exists(self):
         if not self._value:
             return False
-        # A whitespace-only string does indeed exist, so check we
-        # aren't dealing with one of those.
+        # Whitespace-only strings will pass previous check but still do
+        # not "exist" for our purposes, so return False for those too.
         if isinstance(self._value, str) and self._value.isspace():
             return False
         return True

--- a/sheet_to_triples/field.py
+++ b/sheet_to_triples/field.py
@@ -96,7 +96,12 @@ class Cell:
 
     @property
     def as_uc(self):
-        return _must(''.join([x.title() if x.islower() else x for x in re.findall(r'\w+', self._value)]))
+        return _must(
+            ''.join(
+                [x.title() if x.islower()
+                 else x for x in re.findall(r'\w+', self._value)]
+            )
+        )
 
     @property
     def as_lc(self):
@@ -183,8 +188,13 @@ class Cell:
 
     @property
     def exists(self):
-        # Note, a whitespace-only string does exist, may be confusing!
-        return bool(self._value)
+        if not self._value:
+            return False
+        # A whitespace-only string does indeed exist, so check we
+        # aren't dealing with one of those.
+        if isinstance(self._value, str) and self._value.isspace():
+            return False
+        return True
 
     @property
     def not_exists(self):

--- a/sheet_to_triples/field.py
+++ b/sheet_to_triples/field.py
@@ -96,7 +96,7 @@ class Cell:
 
     @property
     def as_uc(self):
-        return _must(self._pattern.sub('', _str(self._value).title()))
+        return _must(''.join([x.title() if x.islower() else x for x in re.findall(r'\w+', self._value)]))
 
     @property
     def as_lc(self):

--- a/sheet_to_triples/tests/test_field.py
+++ b/sheet_to_triples/tests/test_field.py
@@ -233,6 +233,9 @@ class CellTestCase(unittest.TestCase):
     def test_exists_false(self):
         self.assertFalse(field.Cell(None).exists)
 
+    def test_exists_whitespace_false(self):
+        self.assertFalse(field.Cell(' ').exists)
+
     def test_not_exists_true(self):
         self.assertTrue(field.Cell(None).not_exists)
 

--- a/sheet_to_triples/tests/test_trans.py
+++ b/sheet_to_triples/tests/test_trans.py
@@ -299,3 +299,31 @@ class TransformTestCase(unittest.TestCase):
             ['http://b.test/iri', 'http://predicate.test', 'not exists'],
         ]
         self._process_and_assertEqual(details, expected)
+
+    def test_conds_conditional_template(self):
+        # Check that the condition is satisfied before templating conditional values.
+        # This is so that we can use .exists to check if a cell value is not None before
+        # attempting to template it -- previously we got a TypeError as the code would
+        # try to template the True conditional value regardless of the condition.
+        details = {
+            'data': [
+                {'col1': 'http://a.test', 'col2': '1'},
+                {'col1': 'http://b.test', 'col2': None},
+            ],
+            'lets': {
+                'iri': '{row[col1]}/iri'
+            },
+            'conds': {
+                'evaltest': (
+                    '{row[col2].exists}', '{row[col2].as_text}', 'not templated',
+                )
+            },
+            'triples': [
+                ('{iri}', 'http://predicate.test', '{evaltest}'),
+            ]
+        }
+        expected = [
+            ['http://a.test/iri', 'http://predicate.test', '1'],
+            ['http://b.test/iri', 'http://predicate.test', 'not templated'],
+        ]
+        self._process_and_assertEqual(details, expected)

--- a/sheet_to_triples/trans.py
+++ b/sheet_to_triples/trans.py
@@ -170,10 +170,12 @@ class Transform:
             params[k] = converter.as_obj(self.lets[k], params) or ''
 
         for c in self.conds:
-            cond, true, false = (
-                converter.as_obj(n, params) for n in self.conds[c]
-            )
-            params[c] = str(true) if str(cond) == "True" else str(false)
+            cond, true, false = self.conds[c]
+            convert = lambda x: str(converter.as_obj(x, params))
+            if convert(cond) == "True":
+                params[c] = convert(true)
+            else:
+                params[c] = convert(false)
 
         for k, q in query_map.items():
             result = list(q(initBindings=params))

--- a/sheet_to_triples/trans.py
+++ b/sheet_to_triples/trans.py
@@ -165,17 +165,19 @@ class Transform:
     def _generate_params(self, converter, query_map, row, n):
         params = dict(query={}, row=row, n=n)
 
+        def _convert(template):
+            return converter.as_obj(template, params)
+        
         for k in self.lets:
             # TODO: Defaulting to empty string is wrong if variable can't bind
-            params[k] = converter.as_obj(self.lets[k], params) or ''
-
+            params[k] = _convert(self.lets[k]) or ''
+        
         for c in self.conds:
             cond, true, false = self.conds[c]
-            convert = lambda x: str(converter.as_obj(x, params))
-            if convert(cond) == "True":
-                params[c] = convert(true)
+            if str(_convert(cond)) == "True":
+                params[c] = _convert(true)
             else:
-                params[c] = convert(false)
+                params[c] = _convert(false)
 
         for k, q in query_map.items():
             result = list(q(initBindings=params))

--- a/sheet_to_triples/trans.py
+++ b/sheet_to_triples/trans.py
@@ -174,7 +174,7 @@ class Transform:
         
         for c in self.conds:
             cond, true, false = self.conds[c]
-            if str(_convert(cond)) == "True":
+            if all([_convert(c.strip()) == "True" for c in '&'.split(cond)]):
                 params[c] = _convert(true)
             else:
                 params[c] = _convert(false)

--- a/sheet_to_triples/trans.py
+++ b/sheet_to_triples/trans.py
@@ -167,14 +167,14 @@ class Transform:
 
         def _convert(template):
             return converter.as_obj(template, params)
-        
+
         for k in self.lets:
             # TODO: Defaulting to empty string is wrong if variable can't bind
             params[k] = _convert(self.lets[k]) or ''
-        
+
         for c in self.conds:
             cond, true, false = self.conds[c]
-            if all([_convert(c.strip()) == "True" for c in '&'.split(cond)]):
+            if all([str(_convert(c.strip())) == "True" for c in cond.split('&')]):
                 params[c] = _convert(true)
             else:
                 params[c] = _convert(false)


### PR DESCRIPTION
- Treat whitespace-only strings as False when checking for a `.exists` condition.
- Do not attempt to template conditional values before first evaluating the condition and selecting the appropriate value to template.