### PR TITLE
Make Resolver class and make from_identifier a class method

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,8 +21,7 @@ xlrd = "^2"
 [tool.poetry.dev-dependencies]
 ruff = "^0.0.292"
 coverage = "^7"
-# Change to "^5" with release of kipple fix pyfakefs#869
-pyfakefs = "5.1.0"
+pyfakefs = "^5"
 
 [tool.ruff]
 select = ["C9", "E", "F", "W"]

--- a/sheet_to_triples/trans.py
+++ b/sheet_to_triples/trans.py
@@ -36,12 +36,13 @@ class _Converter:
 
     def __init__(self, reference_graph):
         self.vformat = string.Formatter().vformat
-        self.resolver = reference_graph.store.namespace
-        self.from_identifier = rdf.Resolver(reference_graph).from_identifier
+        # TODO: Integrate from_qname into new Resolver class and remove this
+        self._old_resolver = reference_graph.store.namespace
+        self.resolver = rdf.Resolver.from_graph(reference_graph)
 
     def as_iri(self, template, params):
         result = self.vformat(template, (), params)
-        return rdf.from_qname(result, self.resolver)
+        return rdf.from_qname(result, self._old_resolver)
 
     def as_iri_or_none(self, template, params):
         try:
@@ -51,14 +52,14 @@ class _Converter:
         if not result:
             # TODO: Raise in this case, partial rows are problems here
             return None
-        return rdf.from_qname(result, self.resolver)
+        return rdf.from_qname(result, self._old_resolver)
 
     def as_obj(self, template, params):
         try:
             result = self.vformat(template, (), params)
         except (IndexError, KeyError, ValueError):
             return None
-        return self.from_identifier(result)
+        return self.resolver.from_identifier(result)
 
 
 class Transform:

--- a/sheet_to_triples/trans.py
+++ b/sheet_to_triples/trans.py
@@ -37,6 +37,7 @@ class _Converter:
     def __init__(self, reference_graph):
         self.vformat = string.Formatter().vformat
         self.resolver = reference_graph.store.namespace
+        self.from_identifier = rdf.Resolver(reference_graph).from_identifier
 
     def as_iri(self, template, params):
         result = self.vformat(template, (), params)
@@ -57,7 +58,7 @@ class _Converter:
             result = self.vformat(template, (), params)
         except (IndexError, KeyError, ValueError):
             return None
-        return rdf.from_identifier(result, self.resolver)
+        return self.from_identifier(result)
 
 
 class Transform:


### PR DESCRIPTION
The rationale for this is somewhat long and complicated and summarised in https://github.com/VisualMeaning/map-tools/pull/97. The tl;dr is: we want to add handling for the `gist` namespace, which starts with `https` rather than `http`, and under the current `from_identifier` implementation this leads to some undesirable behaviour as it tries to serialise every single URL it sees in an object value as a `URIRef`. We need to _only_ do this for URLs which are actually IRIs, and the best metric we have for this is "does this URL string match any of our graph namespaces", which means `from_identifier` needs access to the graph whenever it's called. Hence the rewrite with `from_identifier` as a method on a `Resolver` class that's initialised with the graph.

Also actually add handling for the `gist` namespace, and a driveby fix on `pyfakefs` versioning as the mentioned PR has been landed and the current pinned version errors out.

[JIRA ticket](https://visual-meaning.atlassian.net/browse/SMP-2152)