### PR TITLE
Update pyproject.toml so that we can pip install sheet_to_triples as a package via setuptools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,14 @@
+[project]
+name = "sheet-to-triples"
+license = {file="COPYING", name="GPL-3.0-or-later"}
+version = "0.1.0"
+authors = [{"name"="Martin Packman", "email"="martin.packman@visual-meaning.com"}]
+description = "Convert tabular data into triples."
+
+# Poetry have their own build metadata block and can't use the one in [project]
+# TODO: Replace poetry with a dependency management tool that can.
 [tool.poetry]
 name = "sheet-to-triples"
-license = "GPL-3.0-or-later"
 version = "0.1.0"
 authors = ["Martin Packman <martin.packman@visual-meaning.com>"]
 description = "Convert tabular data into triples."
@@ -25,3 +33,6 @@ pyfakefs = "^5"
 
 [tool.ruff]
 select = ["C9", "E", "F", "W"]
+
+[tool.setuptools]
+packages = ["sheet_to_triples"]


### PR DESCRIPTION
We'd like to install this repo as a package so that other projects can use the rdf parsing code. This requires some changes to pyproject.toml to make setuptools work according to [PEP 621](https://peps.python.org/pep-0621/).

 Follow-on work from [SMP-2152](https://visual-meaning.atlassian.net/browse/SMP-2152).

[SMP-2152]: https://visual-meaning.atlassian.net/browse/SMP-2152?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ