### PR TITLE
DRAFT: Add option to keep oldest triples when dropping duplicates

### DIFF
--- a/sheet_to_triples/__main__.py
+++ b/sheet_to_triples/__main__.py
@@ -82,8 +82,12 @@ def parse_args(argv):
         '--no-resolve-same', action='store_false', dest='resolve_same',
         help='keep triples that mark same identity in output model')
     parser.add_argument(
-        '--drop-duplicates', choices=['keep-newest', 'keep-oldest'], default='keep-newest',
-        help='Which triples to keep when dropping duplicates during model normalisation')
+        '--drop-duplicates',
+        choices=['keep-newest', 'keep-oldest'],
+        default='keep-newest',
+        help=('Which triples to keep when dropping duplicates during '
+              'model normalisation'),
+        )
     parser.add_argument(
         '--debug', action='store_true', help='debug interactively any error')
     parser.add_argument(

--- a/sheet_to_triples/__main__.py
+++ b/sheet_to_triples/__main__.py
@@ -82,6 +82,9 @@ def parse_args(argv):
         '--no-resolve-same', action='store_false', dest='resolve_same',
         help='keep triples that mark same identity in output model')
     parser.add_argument(
+        '--drop-duplicates', choices=['keep-newest', 'keep-oldest'], default='keep-newest',
+        help='Which triples to keep when dropping duplicates during model normalisation')
+    parser.add_argument(
         '--debug', action='store_true', help='debug interactively any error')
     parser.add_argument(
         '-v', '--verbose', action='store_true', help='show details as turtle')

--- a/sheet_to_triples/rdf.py
+++ b/sheet_to_triples/rdf.py
@@ -172,7 +172,7 @@ def _obj_for_print(obj):
     return '\n#  '.join(str(obj).splitlines())
 
 
-def normalise_model(model, ns, non_uniques, resolve_same, verbose):
+def normalise_model(model, ns, non_uniques, resolve_same, drop_duplicates, verbose):
     terms = model['terms']
     # Record subjects that have been renamed so triples can be moved over
     same = {}
@@ -190,7 +190,8 @@ def normalise_model(model, ns, non_uniques, resolve_same, verbose):
     # While multiple objects for a subject, predicate are generally fine
     # Our model asserts uniqueness, so discard older values.
     by_key = {}
-    for t in terms:
+    iter_terms = reversed(terms) if drop_duplicates == 'keep-oldest' else terms
+    for t in iter_terms:
         for k in ('subj', 'pred', 'obj'):
             if t[k] in same:
                 t[k] = same[t[k]]

--- a/sheet_to_triples/run.py
+++ b/sheet_to_triples/run.py
@@ -31,6 +31,7 @@ class Runner:
         model,
         purge_except,
         resolve_same,
+        drop_duplicates,
         verbose,
         non_unique=None
     ):
@@ -45,6 +46,7 @@ class Runner:
         if self.non_unique is None:
             self.non_unique = _default_non_unique
         self.resolve_same = resolve_same
+        self.drop_duplicates = drop_duplicates
         self.verbose = verbose
 
     @classmethod
@@ -55,7 +57,7 @@ class Runner:
             book = dict()
         model = args.model and cls.load_model(args.model)
         return cls(
-            book, model, args.purge_except, args.resolve_same, args.verbose)
+            book, model, args.purge_except, args.resolve_same, args.drop_duplicates, args.verbose)
 
     def use_non_uniques(self, old_transforms):
         for tf in old_transforms:
@@ -81,7 +83,7 @@ class Runner:
 
         if self.model:
             rdf.normalise_model(
-                self.model, self.ns, self.non_unique, self.resolve_same,
+                self.model, self.ns, self.non_unique, self.resolve_same, self.drop_duplicates,
                 self.verbose)
 
     @property

--- a/sheet_to_triples/run.py
+++ b/sheet_to_triples/run.py
@@ -57,7 +57,13 @@ class Runner:
             book = dict()
         model = args.model and cls.load_model(args.model)
         return cls(
-            book, model, args.purge_except, args.resolve_same, args.drop_duplicates, args.verbose)
+            book,
+            model,
+            args.purge_except,
+            args.resolve_same,
+            args.drop_duplicates,
+            args.verbose,
+        )
 
     def use_non_uniques(self, old_transforms):
         for tf in old_transforms:
@@ -83,8 +89,13 @@ class Runner:
 
         if self.model:
             rdf.normalise_model(
-                self.model, self.ns, self.non_unique, self.resolve_same, self.drop_duplicates,
-                self.verbose)
+                self.model,
+                self.ns,
+                self.non_unique,
+                self.resolve_same,
+                self.drop_duplicates,
+                self.verbose,
+            )
 
     @property
     def ns(self):

--- a/sheet_to_triples/tests/test_rdf.py
+++ b/sheet_to_triples/tests/test_rdf.py
@@ -259,7 +259,7 @@ class TestRDF(unittest.TestCase):
         ]
         model = self._model_from_triples(triples)
         with mock.patch('sys.stdout', new=io.StringIO()) as fake_out:
-            rdf.normalise_model(model, self.namespace_manager, [], True, False)
+            self._normalise_model(model, args={'resolve_same': True})
         self.assertRegex(fake_out.getvalue(), r'^# dropping .*obj1\n#\s+obj2\n$')
 
     def test_normalise_model_ordering(self):

--- a/sheet_to_triples/tests/test_rdf.py
+++ b/sheet_to_triples/tests/test_rdf.py
@@ -174,7 +174,36 @@ class TestRDF(unittest.TestCase):
         terms = [{'subj': s, 'pred': p, 'obj': o} for s, p, o in triples]
         return {'terms': terms}
 
+    def _normalise_model(self, model, args=dict()):
+        # helper to run rdf.normalise_model without having to set every arg
+        default_args = {
+            'model': model,
+            'ns': self.namespace_manager,
+            'non_uniques': [],
+            'resolve_same': False,
+            'drop_duplicates': 'keep-newest',
+            'verbose': False,
+        }
+        for arg, value in args.items():
+            default_args[arg] = value
+        rdf.normalise_model(**default_args)
+
     def test_normalise_model_unique_predicate(self):
+        triples = [
+            ('test_subj', 'test_pred', 'test_obj'),
+            ('test_subj', 'test_pred', 'test_obj2')
+        ]
+        model = self._model_from_triples(triples)
+        with mock.patch('sys.stdout', new=io.StringIO()) as fake_out:
+            self._normalise_model(model)
+        # it should take the last recorded triple in the list
+        expected_triples = [
+            ('test_subj', 'test_pred', 'test_obj2'),
+        ]
+        self.assertEqual(model, self._model_from_triples(expected_triples))
+        self.assertRegex(fake_out.getvalue(), r'^# dropping .*$')
+
+    def test_normalise_model_unique_predicate_keep_oldest(self):
         triples = [
             ('test_subj', 'test_pred', 'test_obj'),
             ('test_subj', 'test_pred', 'test_obj2')
@@ -182,12 +211,10 @@ class TestRDF(unittest.TestCase):
         model = self._model_from_triples(triples)
 
         with mock.patch('sys.stdout', new=io.StringIO()) as fake_out:
-            rdf.normalise_model(
-                model, self.namespace_manager, [], False, False)
-
-        # it should take the last recorded triple in the list
+            self._normalise_model(model, args={'drop_duplicates': 'keep-oldest'})
+        # it should take the first recorded triple in the list
         expected_triples = [
-            ('test_subj', 'test_pred', 'test_obj2'),
+            ('test_subj', 'test_pred', 'test_obj'),
         ]
         self.assertEqual(model, self._model_from_triples(expected_triples))
         self.assertRegex(fake_out.getvalue(), r'^# dropping .*$')
@@ -199,8 +226,7 @@ class TestRDF(unittest.TestCase):
             ('test_subj', 'test_pred', 'test_obj2'),
         ]
         model = self._model_from_triples(triples)
-        rdf.normalise_model(
-            model, self.namespace_manager, ['test_pred'], False, False)
+        self._normalise_model(model, args={'non_uniques': ['test_pred']})
         # should allow multiple obj values for one predicate
         expected_triples = [
             ('test_subj', 'test_pred', 'test_obj'),
@@ -218,7 +244,7 @@ class TestRDF(unittest.TestCase):
         ]
         model = self._model_from_triples(triples)
         with mock.patch('sys.stdout', new=io.StringIO()) as fake_out:
-            rdf.normalise_model(model, self.namespace_manager, [], True, False)
+            self._normalise_model(model, args={'resolve_same': True})
         expected_triples = [
             ('test_subj', 'test_pred', 'test_obj'),
             ('test_subj', 'test_pred2', 'test_obj2'),
@@ -244,9 +270,7 @@ class TestRDF(unittest.TestCase):
             ('test_subj1', 'test_pred1', 'test_obj1'),
         ]
         model = self._model_from_triples(triples)
-        rdf.normalise_model(
-            model, self.namespace_manager, ['test_pred1'], False, False)
-
+        self._normalise_model(model, args={'non_uniques': ['test_pred1']})
         expected_triples = [
             ('test_subj1', 'test_pred1', 'test_obj2'),
             ('test_subj1', 'test_pred1', 'test_obj1'),

--- a/sheet_to_triples/tests/test_run.py
+++ b/sheet_to_triples/tests/test_run.py
@@ -62,6 +62,7 @@ class StubRunner:
             'model': model,
             'purge_except': lambda x: True,
             'resolve_same': False,
+            'drop_duplicates': 'keep-newest',
             'verbose': False,
             'non_unique': set(),
         }
@@ -83,6 +84,7 @@ class RunnerTestCase(unittest.TestCase):
             'model': 'model.json',
             'purge_except': lambda x: True,
             'resolve_same': False,
+            'drop_duplicates': 'keep-newest',
             'verbose': False,
         }
         args = StubArgs(argvalues)
@@ -99,6 +101,7 @@ class RunnerTestCase(unittest.TestCase):
             ('books', expected_books),
             ('model', model),
             ('resolve_same', False),
+            ('drop_duplicates', 'keep-newest'),
             ('verbose', False),
             ('non_unique', run._default_non_unique),
         ]
@@ -116,6 +119,7 @@ class RunnerTestCase(unittest.TestCase):
             'model': 'model.json',
             'purge_except': lambda x: True,
             'resolve_same': False,
+            'drop_duplicates': 'keep-newest',
             'verbose': False,
         }
         args = StubArgs(argvalues)
@@ -131,6 +135,7 @@ class RunnerTestCase(unittest.TestCase):
             'model': run.default_model,
             'purge_except': lambda x: True,
             'resolve_same': False,
+            'drop_duplicates': 'keep-newest',
             'verbose': False,
         }
         args = StubArgs(argvalues)
@@ -144,6 +149,7 @@ class RunnerTestCase(unittest.TestCase):
             'model': None,
             'purge_except': lambda x: True,
             'resolve_same': False,
+            'drop_duplicates': 'keep-newest',
             'verbose': False,
         }
         args = StubArgs(argvalues)


### PR DESCRIPTION
We typically create our models over two passes, once to create a model from Excel data, and then a second one to add in labels triples. Since we currently drop the oldest triple where duplicates are found, this means that the labels triples always "win" - however, we usually treat our Excel data as a source of truth so it's these older triples that should be retained.

So, add option to select behaviour when dropping duplicates. Default is the existing `keep-newest` behaviour as this is appropriate when building the Excel model itself, but allow `keep-oldest` instead at the user's discretion.