### PR TITLE
Comment out multi-line literals when printing with `--verbose`

### DIFF
--- a/sheet_to_triples/rdf.py
+++ b/sheet_to_triples/rdf.py
@@ -165,6 +165,13 @@ def _to_key(t, non_uniques):
     return t['subj'], t['pred']
 
 
+def _obj_for_print(obj):
+    """Comment out all lines of newline separated string."""
+    if not isinstance(obj, rdflib.Literal):
+        return obj
+    return '\n#  '.join(str(obj).splitlines())
+
+
 def normalise_model(model, ns, non_uniques, resolve_same, verbose):
     terms = model['terms']
     # Record subjects that have been renamed so triples can be moved over
@@ -190,7 +197,10 @@ def normalise_model(model, ns, non_uniques, resolve_same, verbose):
         key = _to_key(t, non_uniques)
         if key in by_key and (verbose or by_key[key]['obj'] != t['obj']):
             print('# dropping {s} {p} {o}'.format(
-                s=_n3(key[0], ns), p=_n3(key[1], ns), o=by_key[key]['obj']))
+                s=_n3(key[0], ns),
+                p=_n3(key[1], ns),
+                o=_obj_for_print(by_key[key]['obj'])
+            ))
         by_key[key] = t
 
     order_pred = VM.asOrdinal.toPython()

--- a/sheet_to_triples/tests/test_rdf.py
+++ b/sheet_to_triples/tests/test_rdf.py
@@ -226,6 +226,16 @@ class TestRDF(unittest.TestCase):
         self.assertEqual(model, self._model_from_triples(expected_triples))
         self.assertRegex(fake_out.getvalue(), r'^# dropping .*$')
 
+    def test_normalise_model_comments_multiple_lines(self):
+        triples = [
+            ('subj', 'pred', rdflib.Literal('obj1\nobj2')),
+            ('subj', 'pred', rdflib.Literal('obj3')),
+        ]
+        model = self._model_from_triples(triples)
+        with mock.patch('sys.stdout', new=io.StringIO()) as fake_out:
+            rdf.normalise_model(model, self.namespace_manager, [], True, False)
+        self.assertRegex(fake_out.getvalue(), r'^# dropping .*obj1\n#\s+obj2\n$')
+
     def test_normalise_model_ordering(self):
         triples = [
             ('test_subj1', 'test_pred2', 'test_obj'),


### PR DESCRIPTION
We have a use case where `--verbose` is used to pipe the graph-as-.ttl stdout to a file. This includes all stdout output, not just the graph .ttl, which means our log lines for dropping duplicate triples are also included in this file. The log line starts with a comment character so most of the time we just get a big bunch of commented out stuff at the start of the file and it's not a problem. However, object Literals consisting of multiline strings are printed as multiple lines, and the subsequent lines after the first are *not* commented, and the file breaks.

Therefore, when printing these log lines detect when the object is an `rdflib.term.Literal`, and if it is insert additional comment characters. 

[JIRA ticket](https://visual-meaning.atlassian.net/browse/SMP-2208)