### PR TITLE
Allow handling of unique predicates to be defined by ontology

### DIFF
--- a/sheet_to_triples/__main__.py
+++ b/sheet_to_triples/__main__.py
@@ -89,6 +89,13 @@ def parse_args(argv):
               'model normalisation'),
         )
     parser.add_argument(
+        '-n', '--use-ontology-normalisation', action='store_true',
+        help=('Unique predicates are defined by owl:functionalProperty in the '
+              'ontology and used for model normalisation. All non-unique '
+              'definitions are ignored, as all predicates are assumed non-unique '
+              ' by default unless specifically defined as unique.')
+    )
+    parser.add_argument(
         '--debug', action='store_true', help='debug interactively any error')
     parser.add_argument(
         '-v', '--verbose', action='store_true', help='show details as turtle')

--- a/sheet_to_triples/rdf.py
+++ b/sheet_to_triples/rdf.py
@@ -200,12 +200,14 @@ def normalise_model(model, ns, norm_params, verbose):
                 del terms[i]
 
     from_onto = norm_params['from_ontology']
-    norm_preds = norm_params['non_uniques'] if not from_onto else _functional_properties(model)
+    norm_preds = norm_params['non_uniques'] if not from_onto \
+                 else _functional_properties(model)
 
     # While multiple objects for a subject, predicate are generally fine
     # Our model asserts uniqueness, so discard older values.
     by_key = {}
-    iter_terms = reversed(terms) if norm_params['drop_duplicates'] == 'keep-oldest' else terms
+    iter_terms = reversed(terms) if norm_params['drop_duplicates'] == 'keep-oldest' \
+                 else terms
     for t in iter_terms:
         for k in ('subj', 'pred', 'obj'):
             if t[k] in same:

--- a/sheet_to_triples/run.py
+++ b/sheet_to_triples/run.py
@@ -43,12 +43,9 @@ class Runner:
             self.graph = rdf.graph_from_model(model)
         else:
             self.graph = rdf.graph_from_triples(())
-        self.non_unique = non_unique
-        if self.non_unique is None:
-            self.non_unique = _default_non_unique
-
         self.normalisation_params = {
-            'non_uniques': _default_non_unique if non_unique is None else non_unique,
+            'non_uniques': _default_non_unique.copy() if non_unique is None \
+                           else non_unique,
             'from_ontology': use_ontology_normalisation,
             'drop_duplicates': drop_duplicates,
             'resolve_same': resolve_same

--- a/sheet_to_triples/run.py
+++ b/sheet_to_triples/run.py
@@ -46,10 +46,10 @@ class Runner:
         self.non_unique = non_unique
         if self.non_unique is None:
             self.non_unique = _default_non_unique
-        
+
         self.normalisation_params = {
             'non_uniques': _default_non_unique if non_unique is None else non_unique,
-            'from_ontology': use_ontology_normalisation, 
+            'from_ontology': use_ontology_normalisation,
             'drop_duplicates': drop_duplicates,
             'resolve_same': resolve_same
         }

--- a/sheet_to_triples/tests/test_main.py
+++ b/sheet_to_triples/tests/test_main.py
@@ -287,6 +287,6 @@ class TestMain(fake_filesystem_unittest.TestCase):
         runner = run.Runner.from_args(args)
         main.run_runner(runner, args)
         self.assertEqual(
-            runner.non_unique,
+            runner.normalisation_params['non_uniques'],
             non_uniques.union(run._default_non_unique),
         )

--- a/sheet_to_triples/tests/test_rdf.py
+++ b/sheet_to_triples/tests/test_rdf.py
@@ -245,14 +245,16 @@ class TestRDF(unittest.TestCase):
             ('test_subj', 'test_pred', 'test_obj2'),
             ('test_subj', 'test_pred2', 'test_obj3'),
             ('test_subj', 'test_pred2', 'test_obj4'),
-            ('test_pred', rdflib.namespace.RDF['type'], rdflib.namespace.OWL['FunctionalProperty']),
+            ('test_pred', rdflib.namespace.RDF['type'],
+               rdflib.namespace.OWL['FunctionalProperty']),
         ]
         model = self._model_from_triples(triples)
         with mock.patch('sys.stdout', new=io.StringIO()) as fake_out:
             self._normalise_model(model, norm_params={'from_ontology': True})
         # should only allow one obj value for test_pred, but multiple for test_pred2
         expected_triples = [
-            ('test_pred', rdflib.namespace.RDF['type'], rdflib.namespace.OWL['FunctionalProperty']),
+            ('test_pred', rdflib.namespace.RDF['type'],
+               rdflib.namespace.OWL['FunctionalProperty']),
             ('test_subj', 'test_pred', 'test_obj2'),
             ('test_subj', 'test_pred2', 'test_obj3'),
             ('test_subj', 'test_pred2', 'test_obj4'),

--- a/sheet_to_triples/tests/test_rdf.py
+++ b/sheet_to_triples/tests/test_rdf.py
@@ -234,6 +234,24 @@ class TestRDF(unittest.TestCase):
         ]
         self.assertEqual(model, self._model_from_triples(expected_triples))
 
+    def test_normalise_model_non_unique_from_model(self):
+        triples = [
+            ('test_subj', 'test_pred', 'test_obj'),
+            ('test_subj', 'test_pred', 'test_obj'),
+            ('test_subj', 'test_pred', 'test_obj2'),
+            ('test_pred', rdf.VM['nonUnique'], 'true'),
+        ]
+        model = self._model_from_triples(triples)
+        rdf.normalise_model(
+            model, self.namespace_manager, [], False, False)
+        # should allow multiple obj values for one predicate
+        expected_triples = [
+            ('test_pred', rdf.VM['nonUnique'], 'true'),
+            ('test_subj', 'test_pred', 'test_obj'),
+            ('test_subj', 'test_pred', 'test_obj2'),
+        ]
+        self.assertEqual(model, self._model_from_triples(expected_triples))
+
     def test_normalise_model_resolve_same(self):
         triples = [
             ('test_subj', 'test_pred', 'test_obj'),

--- a/sheet_to_triples/tests/test_run.py
+++ b/sheet_to_triples/tests/test_run.py
@@ -62,6 +62,7 @@ class StubRunner:
             'model': model,
             'purge_except': lambda x: True,
             'resolve_same': False,
+            'use_ontology_normalisation': False,
             'drop_duplicates': 'keep-newest',
             'verbose': False,
             'non_unique': set(),
@@ -84,6 +85,7 @@ class RunnerTestCase(unittest.TestCase):
             'model': 'model.json',
             'purge_except': lambda x: True,
             'resolve_same': False,
+            'use_ontology_normalisation': False,
             'drop_duplicates': 'keep-newest',
             'verbose': False,
         }
@@ -92,7 +94,6 @@ class RunnerTestCase(unittest.TestCase):
 
         with _mock_basename(), _mock_xl_load_book(), _mock_open(model_data):
             runner = run.Runner.from_args(args)
-
         expected_books = {
             '/basename/test_book1.xlsx': '/load_book/test_book1.xlsx',
             '/basename/test_book2.xlsx': '/load_book/test_book2.xlsx',
@@ -100,10 +101,13 @@ class RunnerTestCase(unittest.TestCase):
         expected_attrs = [
             ('books', expected_books),
             ('model', model),
-            ('resolve_same', False),
-            ('drop_duplicates', 'keep-newest'),
+            ('normalisation_params', {
+                'from_ontology': False,
+                'resolve_same': False,
+                'drop_duplicates': 'keep-newest',
+                'non_uniques': run._default_non_unique
+            }),
             ('verbose', False),
-            ('non_unique', run._default_non_unique),
         ]
         for attr, expected in expected_attrs:
             with self.subTest(attr=attr):
@@ -119,6 +123,7 @@ class RunnerTestCase(unittest.TestCase):
             'model': 'model.json',
             'purge_except': lambda x: True,
             'resolve_same': False,
+            'use_ontology_normalisation': False,
             'drop_duplicates': 'keep-newest',
             'verbose': False,
         }
@@ -135,6 +140,7 @@ class RunnerTestCase(unittest.TestCase):
             'model': run.default_model,
             'purge_except': lambda x: True,
             'resolve_same': False,
+            'use_ontology_normalisation': False,
             'drop_duplicates': 'keep-newest',
             'verbose': False,
         }
@@ -149,6 +155,7 @@ class RunnerTestCase(unittest.TestCase):
             'model': None,
             'purge_except': lambda x: True,
             'resolve_same': False,
+            'use_ontology_normalisation': False,
             'drop_duplicates': 'keep-newest',
             'verbose': False,
         }

--- a/sheet_to_triples/tests/test_run.py
+++ b/sheet_to_triples/tests/test_run.py
@@ -177,7 +177,7 @@ class RunnerTestCase(unittest.TestCase):
         runner = StubRunner().get_runner()
         runner.use_non_uniques(transforms)
         self.assertEqual(
-            runner.non_unique,
+            runner.normalisation_params['non_uniques'],
             {'http://a.test', 'http://b.test'},
         )
 
@@ -248,7 +248,10 @@ class RunnerTestCase(unittest.TestCase):
         # initialise with non-empty default non_unique list
         runner = StubRunner().get_runner({'non_unique': {'http://a.test'}})
         runner.run([transform])
-        self.assertEqual(runner.non_unique, {'http://a.test', 'http://pred'})
+        self.assertEqual(
+            runner.normalisation_params['non_uniques'],
+            {'http://a.test', 'http://pred'},
+        )
 
     def _create_row_iter(self, rows):
         row_iter = []


### PR DESCRIPTION
This has come up a couple of times: previously we weren't regularly using ontologies in our projects, so we had to define non-unique predicates at the transform level. Now that we *are* using ontologies, we can define how we handle predicates at the ontology level.

This change adds a flag `--use-ontology-normalisation`. If the flag is passed, all predicates are assumed non-unique by default. All `non_unique` parameters will be ignored. During normalisation, we search through the model to find subject IRIs which are of type `owl:FunctionalProperty` - the [OWL definition](https://www.w3.org/TR/owl-ref/#FunctionalProperty-def) for this states that Functional Properties may only have a single value - or in other words, it is a unique predicate.

We then use our set of FunctionalProperties to normalise with inverse behaviour to how we've previously done it, treating all predicates as non-unique unless they're in the set of FunctionalProperties.

[JIRA ticket](https://visual-meaning.atlassian.net/browse/SMP-2234)