### PR TITLE
Use strings for comparison against model terms

### DIFF
--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -23,7 +23,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: install
         run: |
-          pip3 install poetry
+          pip3 install 'poetry<2.0.0'
           poetry install --no-root
       - name: test
         run: |

--- a/sheet_to_triples/rdf.py
+++ b/sheet_to_triples/rdf.py
@@ -179,7 +179,7 @@ def _functional_properties(model):
     uniques = set()
     # going through whole model again to do this is expensive
     for t in model['terms']:
-        if t['pred'] == rdf['type'] and t['obj'] == owl['FunctionalProperty']:
+        if t['pred'] == str(rdf['type']) and t['obj'] == str(owl['FunctionalProperty']):
             uniques.add(t['subj'])
     return uniques
 

--- a/sheet_to_triples/tests/test_rdf.py
+++ b/sheet_to_triples/tests/test_rdf.py
@@ -240,21 +240,22 @@ class TestRDF(unittest.TestCase):
         self.assertEqual(model, self._model_from_triples(expected_triples))
 
     def test_normalise_model_from_ontology(self):
+        # terms as read from JSON will have string versions of these IRIs
+        str_rdftype = str(rdflib.namespace.RDF['type'])
+        str_functionalproperty = str(rdflib.namespace.OWL['FunctionalProperty'])
         triples = [
             ('test_subj', 'test_pred', 'test_obj'),
             ('test_subj', 'test_pred', 'test_obj2'),
             ('test_subj', 'test_pred2', 'test_obj3'),
             ('test_subj', 'test_pred2', 'test_obj4'),
-            ('test_pred', rdflib.namespace.RDF['type'],
-               rdflib.namespace.OWL['FunctionalProperty']),
+            ('test_pred', str_rdftype, str_functionalproperty),
         ]
         model = self._model_from_triples(triples)
         with mock.patch('sys.stdout', new=io.StringIO()) as fake_out:
             self._normalise_model(model, norm_params={'from_ontology': True})
         # should only allow one obj value for test_pred, but multiple for test_pred2
         expected_triples = [
-            ('test_pred', rdflib.namespace.RDF['type'],
-               rdflib.namespace.OWL['FunctionalProperty']),
+            ('test_pred', str_rdftype, str_functionalproperty),
             ('test_subj', 'test_pred', 'test_obj2'),
             ('test_subj', 'test_pred2', 'test_obj3'),
             ('test_subj', 'test_pred2', 'test_obj4'),


### PR DESCRIPTION
A user reported that the `--use-ontology-normalisation` parameter in sheet-to-triples was not deduping `owl:FunctionalProperties` at all. 



The offending line of code is fixed as part of this PR.

`t['pred']` and `t['obj']` are the predicate and object IRIs/values as pulled out of the model JSON via `json.load`. This means that they are strings. `rdf['type']` and `owl['FunctionalProperty']` are derived from `rdflib.Namespace` and are therefore `rdflib` constructs (I think `URIRef`). This means that they are not strings.

Therefore this comparison will never be true, and the list of Functional Properties for deduping will always be empty.

To fix, cast the `rdflib` bits to string during comparison.

[SMP-3205](https://visual-meaning.atlassian.net/browse/SMP-3205)


[SMP-3205]: https://visual-meaning.atlassian.net/browse/SMP-3205?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ