### PR TITLE
Update pyproject.toml to be compatible with poetry 2

### DIFF
--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -23,7 +23,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: install
         run: |
-          pip3 install 'poetry>=2'
+          pip3 install poetry
           poetry install --no-root
       - name: test
         run: |

--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -23,7 +23,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: install
         run: |
-          pip3 install 'poetry<2.0.0'
+          pip3 install 'poetry>=2'
           poetry install --no-root
       - name: test
         run: |

--- a/.github/workflows/gate.yml
+++ b/.github/workflows/gate.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.11"]
+        python-version: ["3.9", "3.13"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v4

--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ What the code in this repo actually does!
 
 ### prerequisites
 
+> [!NOTE]
+> Poetry 2 [introduced breaking changes](https://github.com/python-poetry/poetry/issues/9136) that are not backwards compatible with Poetry 1. The pyproject.toml is compatible with Poetry 2 only - this is installed by default using the below instructions, but if you are using an already-installed copy of Poetry you should make sure to upgrade it to version 2.
+
 - Install poetry https://python-poetry.org/docs/#installation
 
 - Run the following command to set up the dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = [{"name"="Martin Packman", "email"="martin.packman@visual-meaning.com"
 description = "Convert tabular data into triples."
 
 [tool.poetry.dependencies]
-python = "^3.8.10"
+python = "^3.9.13"
 pycountry = "^22"
 # openpyxl broke parsing some workbooks with filters and the maintainer made
 # the classic mistake of blocking the regression fix on a rethink of how

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,16 +1,9 @@
 [project]
 name = "sheet-to-triples"
-license = {file="COPYING", name="GPL-3.0-or-later"}
+license = "GPL-3.0-or-later"
+license-files = ["COPYING"]
 version = "0.1.0"
 authors = [{"name"="Martin Packman", "email"="martin.packman@visual-meaning.com"}]
-description = "Convert tabular data into triples."
-
-# Poetry have their own build metadata block and can't use the one in [project]
-# TODO: Replace poetry with a dependency management tool that can.
-[tool.poetry]
-name = "sheet-to-triples"
-version = "0.1.0"
-authors = ["Martin Packman <martin.packman@visual-meaning.com>"]
 description = "Convert tabular data into triples."
 
 [tool.poetry.dependencies]
@@ -26,10 +19,10 @@ openpyxl = "=3.0.10"
 rdflib = {version = "^7", extras = ["sparql"]}
 xlrd = "^2"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 ruff = "^0.0.292"
 coverage = "^7"
-pyfakefs = "^5"
+pyfakefs = "^5.7.0"
 
 [tool.ruff]
 select = ["C9", "E", "F", "W"]


### PR DESCRIPTION
The relevant poetry 2 breaking changes are all to do with how the `pyproject.toml` is formatted:

- It uses the `[project]` block properly now as per PEP 621, resolving a long-standing complaint we've had (see deleted comment).
   - This means we don't need the separate `[tool.poetry]` block any more.
   - However, it's very specific about what it allows to have in its `license` fields, hence the splitting of the existing `license` field into `license` and `license-files`.
- It doesn't have a specific concept of dev dependencies any more, instead making those a generic group of sub-requirements.

Additionally, when running the unittests after these changes, `pyfakefs` went completely bonkers with some kind of infinite recursion bug, so a version bump was necessary in order to fix that.

I've verified this works with both Python 3.8 and 3.13, so we don't need to bump minimum Python version (yet).

[SMP-3234](https://visual-meaning.atlassian.net/browse/SMP-3234)

[SMP-3234]: https://visual-meaning.atlassian.net/browse/SMP-3234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ