### PR TITLE
Unpinning `openpyxl` to ^3.1.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,13 +9,7 @@ description = "Convert tabular data into triples."
 [tool.poetry.dependencies]
 python = "^3.9.13"
 pycountry = "^22"
-# openpyxl broke parsing some workbooks with filters and the maintainer made
-# the classic mistake of blocking the regression fix on a rethink of how
-# filters get handled so the issue has persisted for nearly a year.
-# https://foss.heptapod.net/openpyxl/openpyxl/-/issues/1967
-# https://foss.heptapod.net/openpyxl/openpyxl/-/merge_requests/425
-# Pin the last working version for now.
-openpyxl = "=3.0.10"
+openpyxl = "^3.1.5"
 rdflib = {version = "^7", extras = ["sparql"]}
 xlrd = "^2"
 


### PR DESCRIPTION
`openpyxl` has been pinned in `sheet-to-triples` because of a bug. This bug seems to be no longer active.
This PR proposes to release `openpyxl`'s version to '^3.1.5'.

Verifying the bug:
- In an Excel export file, format a sheet as a table
- Activate dynamic filters
- Save
- Run the corresponding job file (upload_commands from illustrator-to-smp)

Review requested from: @VisualMeaning/devs
JIRA Ticket: [SMP-3267](https://visual-meaning.atlassian.net/browse/SMP-3267)

[SMP-3267]: https://visual-meaning.atlassian.net/browse/SMP-3267?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ