### PR TITLE
Fix roundtrip lang literal conversion

### DIFF
--- a/sheet_to_triples/rdf.py
+++ b/sheet_to_triples/rdf.py
@@ -59,12 +59,9 @@ class Resolver:
             lang = value[-2:]
             value_without_lang = value[:-3]
             if value_without_lang.startswith('"') and value_without_lang.endswith('"'):
-                try:
-                    inner = json.loads(value_without_lang)
-                except json.JSONDecodeError:
-                    # unnecesary fallback?
-                    inner = value_without_lang[1:-1]
+                inner = json.loads(value_without_lang)
             else:
+                # {"k": "v"}@en compatibility
                 inner = value_without_lang
             return rdflib.Literal(inner, lang=lang)
         return rdflib.Literal(value)

--- a/sheet_to_triples/rdf.py
+++ b/sheet_to_triples/rdf.py
@@ -4,6 +4,7 @@
 """Context specific RDF behaviours for Visual Meaning graphs."""
 
 import functools
+import json
 import operator
 import re
 
@@ -55,8 +56,17 @@ class Resolver:
         value = _norm(value)
         # if ends with language tag, create a Literal with the appropriate lang
         if re.search(self.lang_match, value):
-            inner = value[1:-4] if value[0] == '"' else value[:-3]
-            return rdflib.Literal(inner, lang=value[-2:])
+            lang = value[-2:]
+            value_without_lang = value[:-3]
+            if value_without_lang.startswith('"') and value_without_lang.endswith('"'):
+                try:
+                    inner = json.loads(value_without_lang)
+                except json.JSONDecodeError:
+                    # unnecesary fallback?
+                    inner = value_without_lang[1:-1]
+            else:
+                inner = value_without_lang
+            return rdflib.Literal(inner, lang=lang)
         return rdflib.Literal(value)
 
 
@@ -138,9 +148,12 @@ def _maybe_from_literal(maybe_literal):
     them in the json serialisation for both strings and arrays or objects.
     """
     if getattr(maybe_literal, 'language', None):
+        # For JSON arrays/objects, str() gives the JSON representation
         if maybe_literal[:1] + maybe_literal[-1:] in ('[]', '{}'):
             return str(maybe_literal) + '@' + maybe_literal.language
-        return maybe_literal.n3()
+        # For regular strings, use json.dumps to properly escape
+        # This ensures roundtrip compatibility with from_identifier
+        return json.dumps(str(maybe_literal)) + '@' + maybe_literal.language
     return str(maybe_literal)
 
 

--- a/sheet_to_triples/tests/test_rdf.py
+++ b/sheet_to_triples/tests/test_rdf.py
@@ -154,25 +154,26 @@ class TestRDF(unittest.TestCase):
     def test_update_model_terms_language_tags(self):
         """Literals with language tags have special serialisation to terms."""
         model = {'terms': []}
-        test_cases = [
-            (rdflib.URIRef('o:_1'), 'o:_1'),
+        triples = [
+            ('_s', '_p', rdflib.URIRef('o:_1')),
             # Not testing rdflib.Literal(1) as should maybe change behaviour?
-            (rdflib.Literal('o'), 'o'),
-            (rdflib.Literal('o', lang='en'), '"o"@en'),
-            (rdflib.Literal('path\\with\\backslashes', lang='en'),
-             '"path\\\\with\\\\backslashes"@en'),
-            (rdflib.Literal('mixed: "quotes"\nand newlines\tand tabs', lang='en'),
-             '"mixed: \\"quotes\\"\\nand newlines\\tand tabs"@en'),
-            (rdflib.Literal('\u043e', lang='bg'), '"\\u043e"@bg'),
-            (rdflib.Literal('л', lang='bg'), '"\\u043b"@bg'),
-            (rdflib.Literal('', lang='en'), '""@en'),
-            (rdflib.Literal('["o1", "o2"]', lang='en'), '["o1", "o2"]@en'),
-            (rdflib.Literal('{"o": "v"}', lang='en'), '{"o": "v"}@en'),
+            ('_s', '_p', rdflib.Literal('o')),
+            ('_s', '_p', rdflib.Literal('o', lang='en')),
+            ('_s', '_p', rdflib.Literal(
+                'thing: "quotes"\nand newlines\tand tabs', lang='en')),
+            ('_s', '_p', rdflib.Literal('\u043e', lang='bg')),
+            ('_s', '_p', rdflib.Literal('л', lang='bg')),
+            ('_s', '_p', rdflib.Literal('', lang='en')),
+            ('_s', '_p', rdflib.Literal('["o1", "o2"]', lang='en')),
+            ('_s', '_p', rdflib.Literal('{"o": "v"}', lang='en')),
         ]
-        triples = [('_s', '_p', obj) for obj, _ in test_cases]
-        expected = [exp for _, exp in test_cases]
-
         rdf.update_model_terms(model, triples)
+        expected = [
+            'o:_1', 'o', '"o"@en',
+            '"thing: \\"quotes\\"\\nand newlines\\tand tabs"@en',
+            '"\\u043e"@bg', '"\\u043b"@bg', '""@en',
+            '["o1", "o2"]@en', '{"o": "v"}@en',
+        ]
         self.assertEqual([t['obj'] for t in model['terms']], expected)
 
     def _model_from_triples(self, triples):


### PR DESCRIPTION
For localized string `literal.n3()` might not be the best representation in json model.
For example, the output of Cyrillic `о` is `'"\u043b"@bg'`
The proposed casting to term.obj resolves to `'"\\u043b"@bg'` (the language tagged string is serialized) which is more inline with how we feed the string to transform (`.as_json` - applying `json.dumps()`) and how it is consumed (`JSON.parse()`). The simplest way of converting any datatype into a string is stringifying it.

The more important bit is the casting being invertible, allowing a process where a runner outputs a model.json that is sequentially used as input for a second run. Each time converting data to rdflib entities then exported to model.json in string format.

https://visual-meaning.atlassian.net/browse/SMP-3764
@VisualMeaning/devs 